### PR TITLE
Fix: Display specific API errors in toast notifications

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -105,7 +105,10 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
     await sendMessageToTab(tab.id, {
       type: 'SHOW_TOAST',
       payload: {
-        message: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        // Use String(error) to ensure the specific error message is always captured,
+        // as `instanceof Error` can be unreliable across different contexts.
+        // The thrown error from callLLM already contains a descriptive prefix.
+        message: String(error),
         type: 'error',
       },
     });


### PR DESCRIPTION
Previously, the error handling for the API call in `background.ts` would catch detailed errors but display a generic 'Unknown error' message in the toast notification. This happened because the `instanceof Error` check was not reliably capturing the error details thrown from the `callLLM` function.

This change modifies the `catch` block to use `String(error)` as the toast message payload. This ensures that the full, descriptive error message, including the HTTP status and response text from the API, is always displayed to the user. This provides clear, actionable feedback, allowing the user to diagnose issues like an invalid API key.