### PR TITLE
feat: Append concise instruction to manual prompts

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -126,6 +126,10 @@ async function processLLMRequest(text: string, tabId: number, customPrompt?: str
   }
 }
 
+import { DEFAULT_PROMPTS } from './prompts';
+
+const MANUAL_MODE_PROMPT_APPENDIX = 'Please be concise.';
+
 async function callLLM(text: string, settings: ExtensionSettings, customPrompt?: string): Promise<LLMResponse> {
   const { apiKey, apiEndpoint } = settings;
 
@@ -136,13 +140,9 @@ async function callLLM(text: string, settings: ExtensionSettings, customPrompt?:
     'X-Title': 'Ask LLM Extension',
   };
 
-  const systemPrompt = customPrompt || `You are a concise academic assistant.
-Respond with the final answer first, then a brief explanation.
-Format:
-0. If the text received is not a question, respond normally with a 15 word answer and you can disregard points 1-3.
-1. If the text received is a question, start with "Answer: <short answer>" (max ~15 words).
-2. Then 1–4 short sentences explaining why or how.
-3. If unsure, say "Insufficient information".`;
+  const systemPrompt = customPrompt
+    ? `${customPrompt} ${MANUAL_MODE_PROMPT_APPENDIX}`
+    : DEFAULT_PROMPTS.conciseAcademic;
 
   const requestBody = {
     model: 'google/gemini-2.5-flash',

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,0 +1,9 @@
+export const DEFAULT_PROMPTS = {
+  conciseAcademic: `You are a concise academic assistant.
+Respond with the final answer first, then a brief explanation.
+Format:
+0. If the text received is not a question, respond normally with a 15 word answer and you can disregard points 1-3.
+1. If the text received is a question, start with "Answer: <short answer>" (max ~15 words).
+2. Then 1–4 short sentences explaining why or how.
+3. If unsure, say "Insufficient information".`,
+};


### PR DESCRIPTION
Adds "Please be concise." to user-defined prompts in manual mode to encourage shorter LLM responses.

Refactors the default system prompt into a separate `prompts.ts` file for better organization.