### PR TITLE
Feat: Change keyboard shortcut to trigger 'Ask LLM'

### DIFF
--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -40,12 +40,12 @@
     "128": "icons/icon128.png"
   },
   "commands": {
-    "toggle-extension": {
+    "execute-ask-llm": {
       "suggested_key": {
         "default": "Ctrl+Shift+Space",
         "mac": "Command+Shift+Space"
       },
-      "description": "Toggle Ask LLM on/off"
+      "description": "Ask LLM with selected text"
     }
   },
   "web_accessible_resources": [

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -40,12 +40,12 @@
     "128": "icons/icon128.png"
   },
   "commands": {
-    "toggle-extension": {
+    "execute-ask-llm": {
       "suggested_key": {
         "default": "Ctrl+Shift+Space",
         "mac": "Command+Shift+Space"
       },
-      "description": "Toggle Ask LLM on/off"
+      "description": "Ask LLM with selected text"
     }
   },
   "web_accessible_resources": [


### PR DESCRIPTION
This commit changes the behavior of the extension's keyboard shortcut.

Previously, the shortcut (`Ctrl+Shift+Space`) would toggle the extension on or off. Now, it triggers the core "Ask LLM" functionality, using the currently selected text on the page as input.

- Modified `manifest.chrome.json` and `manifest.firefox.json` to rename the command from `toggle-extension` to `execute-ask-llm` and update its description.
- Updated the `browser.commands.onCommand` listener in `background.ts` to execute the "Ask LLM" flow, which includes getting the selected text and calling the `processLLMRequest` function.