### PR TITLE
🎨 Palette: Add API Key visibility toggle

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -26,13 +26,18 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-          />
+          <div class="password-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+            />
+            <button type="button" id="toggleApiKeyVisibility" class="toggle-password" aria-label="Show API key">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>
+            </button>
+          </div>
           <small>Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -22,6 +22,23 @@ const opacityGroup = document.getElementById('opacityGroup') as HTMLDivElement;
 const opacitySlider = document.getElementById('discreteModeOpacity') as HTMLInputElement;
 const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
 
+const EYE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>`;
+const EYE_OFF_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line></svg>`;
+
+const toggleApiKeyVisibilityBtn = document.getElementById('toggleApiKeyVisibility') as HTMLButtonElement;
+
+if (toggleApiKeyVisibilityBtn) {
+  toggleApiKeyVisibilityBtn.addEventListener('click', () => {
+    const type = apiKeyInput.getAttribute('type') === 'password' ? 'text' : 'password';
+    apiKeyInput.setAttribute('type', type);
+
+    // Toggle Icon
+    const isPassword = type === 'password';
+    toggleApiKeyVisibilityBtn.innerHTML = isPassword ? EYE_ICON : EYE_OFF_ICON;
+    toggleApiKeyVisibilityBtn.setAttribute('aria-label', isPassword ? 'Show API key' : 'Hide API key');
+  });
+}
+
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
 };

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -258,3 +258,40 @@ input[type="range"] {
 .btn-icon:hover {
   background: #e5e7eb;
 }
+
+/* Password Toggle Styles */
+.password-wrapper {
+  position: relative;
+}
+
+.password-wrapper input {
+  padding-right: 44px; /* Space for the button */
+}
+
+.toggle-password {
+  position: absolute;
+  right: 2px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 36px;
+  height: 36px;
+  border: none;
+  background: transparent;
+  color: #6b7280;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.toggle-password:hover {
+  color: #374151;
+  background-color: #f3f4f6;
+}
+
+.toggle-password:focus-visible {
+  outline: 2px solid #3b82f6;
+  border-radius: 4px;
+}


### PR DESCRIPTION
Adds a toggle button to the API Key input field in the settings page to show/hide the key. This improves UX by allowing users to verify their input without compromising security by default. The implementation uses inline SVGs for icons and ensures accessibility via aria-labels.

---
*PR created automatically by Jules for task [14277854406391167484](https://jules.google.com/task/14277854406391167484) started by @devin201o*