### PR TITLE
🎨 Palette: Add password toggle for API key

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-21 - Password Toggle Pattern
+**Learning:** For password fields in the options page, the established UI pattern involves wrapping the input in a `.input-wrapper` div and adding an absolutely positioned toggle button (`.toggle-password-btn`) containing an inline SVG.
+**Action:** Reuse this structure and the associated CSS classes (`.input-wrapper`, `.toggle-password-btn`) for any future password visibility toggles to ensure visual consistency and accessibility.

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,17 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" id="toggleApiKeyBtn" class="toggle-password-btn" aria-label="Show API key"></button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,6 +3,7 @@ import { ExtensionSettings, DEFAULT_SETTINGS } from './types';
 const form = document.getElementById('settingsForm') as HTMLFormElement;
 const providerSelect = document.getElementById('provider') as HTMLSelectElement;
 const apiKeyInput = document.getElementById('apiKey') as HTMLInputElement;
+const toggleApiKeyBtn = document.getElementById('toggleApiKeyBtn') as HTMLButtonElement;
 const apiEndpointInput = document.getElementById('apiEndpoint') as HTMLInputElement;
 const modelSelect = document.getElementById('model') as HTMLSelectElement;
 const addModelBtn = document.getElementById('addModelBtn') as HTMLButtonElement;
@@ -25,6 +26,20 @@ const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
 };
+
+const EYE_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+  <circle cx="12" cy="12" r="3" />
+</svg>`;
+
+const EYE_OFF_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
+  <path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68" />
+  <path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61" />
+  <line x1="2" x2="22" y1="2" y2="22" />
+</svg>`;
 
 function updateModelDropdown(models: string[], selectedModel: string) {
   modelSelect.innerHTML = '';
@@ -86,6 +101,17 @@ function updateCustomPromptVisibility() {
 promptModeRadios.forEach(radio => {
   radio.addEventListener('change', updateCustomPromptVisibility);
 });
+
+if (toggleApiKeyBtn) {
+  toggleApiKeyBtn.innerHTML = EYE_ICON;
+
+  toggleApiKeyBtn.addEventListener('click', () => {
+    const isPassword = apiKeyInput.type === 'password';
+    apiKeyInput.type = isPassword ? 'text' : 'password';
+    toggleApiKeyBtn.innerHTML = isPassword ? EYE_OFF_ICON : EYE_ICON;
+    toggleApiKeyBtn.setAttribute('aria-label', isPassword ? 'Hide API key' : 'Show API key');
+  });
+}
 
 providerSelect.addEventListener('change', () => {
   const provider = providerSelect.value as 'openrouter' | 'custom';

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -258,3 +258,39 @@ input[type="range"] {
 .btn-icon:hover {
   background: #e5e7eb;
 }
+
+/* Password Toggle */
+.input-wrapper {
+  position: relative;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+  background-color: #f3f4f6;
+}
+
+.toggle-password-btn svg {
+  width: 20px;
+  height: 20px;
+}
+
+#apiKey {
+  padding-right: 40px;
+}


### PR DESCRIPTION
💡 What: Added a show/hide toggle button to the API key input field in the options page.
🎯 Why: Users need to verify the API key they pasted without clearing the field, improving the configuration experience.
📸 Before/After: Added an eye icon that toggles visibility.
♿ Accessibility: Added `aria-label` that updates between "Show API key" and "Hide API key".

---
*PR created automatically by Jules for task [11593150071646432834](https://jules.google.com/task/11593150071646432834) started by @devin201o*