### PR TITLE
feat: add show/hide toggle for API key in options

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "devDependencies": {
     "@types/chrome": "^0.0.268",
+    "@types/jsdom": "^27.0.0",
+    "@types/node": "^25.2.2",
     "jsdom": "^27.0.0",
     "typescript": "^5.3.3",
     "vite": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@types/chrome':
         specifier: ^0.0.268
         version: 0.0.268
+      '@types/jsdom':
+        specifier: ^27.0.0
+        version: 27.0.0
+      '@types/node':
+        specifier: ^25.2.2
+        version: 25.2.2
       jsdom:
         specifier: ^27.0.0
         version: 27.4.0
@@ -19,13 +25,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^5.0.0
-        version: 5.4.21
+        version: 5.4.21(@types/node@25.2.2)
       vite-plugin-static-copy:
         specifier: ^3.1.3
-        version: 3.2.0(vite@5.4.21)
+        version: 3.2.0(vite@5.4.21(@types/node@25.2.2))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(jsdom@27.4.0)
+        version: 3.2.4(@types/node@25.2.2)(jsdom@27.4.0)
 
 packages:
 
@@ -368,6 +374,15 @@ packages:
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
+  '@types/jsdom@27.0.0':
+    resolution: {integrity: sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw==}
+
+  '@types/node@25.2.2':
+    resolution: {integrity: sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -577,6 +592,9 @@ packages:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
@@ -687,6 +705,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1016,6 +1037,18 @@ snapshots:
 
   '@types/har-format@1.2.16': {}
 
+  '@types/jsdom@27.0.0':
+    dependencies:
+      '@types/node': 25.2.2
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+
+  '@types/node@25.2.2':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@types/tough-cookie@4.0.5': {}
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -1024,13 +1057,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.21)':
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@25.2.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.2.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1259,6 +1292,10 @@ snapshots:
 
   p-map@7.0.4: {}
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
@@ -1371,13 +1408,15 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  vite-node@3.2.4:
+  undici-types@7.16.0: {}
+
+  vite-node@3.2.4(@types/node@25.2.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.2.2)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -1389,27 +1428,28 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-static-copy@3.2.0(vite@5.4.21):
+  vite-plugin-static-copy@3.2.0(vite@5.4.21(@types/node@25.2.2)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.4
       picocolors: 1.1.1
       tinyglobby: 0.2.15
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.2.2)
 
-  vite@5.4.21:
+  vite@5.4.21(@types/node@25.2.2):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.57.1
     optionalDependencies:
+      '@types/node': 25.2.2
       fsevents: 2.3.3
 
-  vitest@3.2.4(jsdom@27.4.0):
+  vitest@3.2.4(@types/node@25.2.2)(jsdom@27.4.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.21)
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@25.2.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1427,10 +1467,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.21
-      vite-node: 3.2.4
+      vite: 5.4.21(@types/node@25.2.2)
+      vite-node: 3.2.4(@types/node@25.2.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 25.2.2
       jsdom: 27.4.0
     transitivePeerDependencies:
       - less

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,22 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" id="toggleApiKeyVisibility" class="toggle-password-btn" aria-label="Show API Key">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.test.ts
+++ b/src/options.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+// Mock chrome API
+const chromeMock = {
+  storage: {
+    local: {
+      get: vi.fn().mockResolvedValue({ settings: {} }),
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+    onChanged: {
+        addListener: vi.fn(),
+    }
+  },
+  runtime: {
+      sendMessage: vi.fn(),
+  }
+};
+
+vi.stubGlobal('chrome', chromeMock);
+
+describe('Options Page', () => {
+  beforeEach(async () => {
+    const dom = new JSDOM(`
+      <!DOCTYPE html>
+      <html>
+      <body>
+        <form id="settingsForm">
+          <select id="provider"><option value="openrouter">OpenRouter</option></select>
+          <div class="input-wrapper">
+             <input type="password" id="apiKey" />
+             <!-- Button will be added here by the implementation -->
+             <button type="button" class="toggle-password-btn" id="toggleApiKeyVisibility"></button>
+          </div>
+          <input id="apiEndpoint" />
+          <select id="model"></select>
+          <button id="addModelBtn"></button>
+          <button id="deleteModelBtn"></button>
+          <input id="maxTokens" />
+          <select id="toastPosition"></select>
+          <input id="toastDuration" />
+          <input type="checkbox" id="toastIndefinite" />
+          <button id="testBtn"></button>
+          <div id="status"></div>
+          <div id="endpointGroup"></div>
+          <input type="radio" name="promptMode" value="auto">
+          <input type="radio" name="promptMode" value="manual">
+          <input type="radio" name="promptMode" value="custom">
+          <div id="customPromptContainer"></div>
+          <textarea id="customPrompt"></textarea>
+          <input type="checkbox" id="discreteMode" />
+          <div id="opacityGroup"></div>
+          <input id="discreteModeOpacity" />
+          <span id="opacityValue"></span>
+        </form>
+      </body>
+      </html>
+    `);
+
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('HTMLInputElement', dom.window.HTMLInputElement);
+    vi.stubGlobal('HTMLFormElement', dom.window.HTMLFormElement);
+    vi.stubGlobal('HTMLSelectElement', dom.window.HTMLSelectElement);
+    vi.stubGlobal('HTMLButtonElement', dom.window.HTMLButtonElement);
+    vi.stubGlobal('HTMLDivElement', dom.window.HTMLDivElement);
+    vi.stubGlobal('HTMLTextAreaElement', dom.window.HTMLTextAreaElement);
+    vi.stubGlobal('HTMLSpanElement', dom.window.HTMLSpanElement);
+
+    // Reset mocks
+    chrome.storage.local.get.mockResolvedValue({ settings: {} });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should toggle password visibility when button is clicked', async () => {
+    // Import the options script to attach event listeners
+    await import('./options.ts?v=' + Date.now());
+
+    const apiKeyInput = document.getElementById('apiKey') as HTMLInputElement;
+    const toggleBtn = document.querySelector('.toggle-password-btn') as HTMLButtonElement;
+
+    expect(apiKeyInput.type).toBe('password');
+
+    // Simulate click
+    // Note: Since we are adding the listener in options.ts, we expect this to work
+    // However, since we haven't implemented it yet, this test might fail or just do nothing if the button exists but no listener
+    // Or fail if button doesn't exist (if I didn't add it in the DOM mock above)
+    // I added it in the DOM mock above so we can test the logic once implemented.
+
+    // But wait, the DOM mock above has the button, but the real options.html doesn't yet.
+    // And options.ts doesn't select it yet.
+
+    // So current options.ts won't attach the listener.
+    // So dispatching click won't change the type.
+
+    toggleBtn.dispatchEvent(new window.Event('click'));
+
+    expect(apiKeyInput.type).toBe('text');
+
+    toggleBtn.dispatchEvent(new window.Event('click'));
+
+    expect(apiKeyInput.type).toBe('password');
+  });
+});

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,6 +21,35 @@ const discreteModeToggle = document.getElementById('discreteMode') as HTMLInputE
 const opacityGroup = document.getElementById('opacityGroup') as HTMLDivElement;
 const opacitySlider = document.getElementById('discreteModeOpacity') as HTMLInputElement;
 const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
+const toggleApiKeyVisibilityBtn = document.getElementById('toggleApiKeyVisibility') as HTMLButtonElement;
+
+const SHOW_ICON = `
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+  </svg>
+`;
+
+const HIDE_ICON = `
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+  </svg>
+`;
+
+if (toggleApiKeyVisibilityBtn) {
+  toggleApiKeyVisibilityBtn.addEventListener('click', () => {
+    const currentType = apiKeyInput.getAttribute('type');
+    if (currentType === 'password') {
+      apiKeyInput.setAttribute('type', 'text');
+      toggleApiKeyVisibilityBtn.setAttribute('aria-label', 'Hide API Key');
+      toggleApiKeyVisibilityBtn.innerHTML = HIDE_ICON;
+    } else {
+      apiKeyInput.setAttribute('type', 'password');
+      toggleApiKeyVisibilityBtn.setAttribute('aria-label', 'Show API Key');
+      toggleApiKeyVisibilityBtn.innerHTML = SHOW_ICON;
+    }
+  });
+}
 
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -258,3 +258,37 @@ input[type="range"] {
 .btn-icon:hover {
   background: #e5e7eb;
 }
+.input-wrapper {
+  position: relative;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #6b7280;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+  background-color: #f3f4f6;
+}
+
+.toggle-password-btn svg {
+  width: 20px;
+  height: 20px;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}


### PR DESCRIPTION
Added a "Show/Hide" toggle button to the API Key input field in the extension's options page. This allows users to easily verify the API key they have entered without it being permanently visible.

**Changes:**
- **`src/options.html`**: Wrapped the `apiKey` input in a container and added a toggle button.
- **`src/styles/options.css`**: Added styles for the input wrapper and the toggle button, including padding to prevent text overlap.
- **`src/options.ts`**: Implemented the logic to switch the input type between `password` and `text` and update the button icon/aria-label.
- **`src/options.test.ts`**: Added a unit test to verify the toggle functionality.
- **`package.json`**: Added `@types/node` and `@types/jsdom` to devDependencies.

**Verification:**
- Verified visually using a Playwright script and screenshot.
- Verified logic using `vitest`.
- Checked accessibility (aria-label updates correctly).

---
*PR created automatically by Jules for task [13850571644435751634](https://jules.google.com/task/13850571644435751634) started by @devin201o*