### PR TITLE
🎨 Palette: Add show/hide toggle for API Key

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-10-27 - [Reusable Password Toggle Pattern]
+**Learning:** In options pages where icon libraries are unavailable, inline SVGs in a `.input-wrapper` provide a lightweight, accessible solution for password visibility toggles.
+**Action:** When adding sensitive inputs, wrap them in `.input-wrapper` with `position: relative`, add `padding-right: 40px` to the input, and use an absolute positioned button with dynamic `aria-label` and inline SVG.

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,22 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" id="toggleApiKeyVisibility" class="toggle-password-btn" aria-label="Show API key">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="20" height="20">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,10 +21,38 @@ const discreteModeToggle = document.getElementById('discreteMode') as HTMLInputE
 const opacityGroup = document.getElementById('opacityGroup') as HTMLDivElement;
 const opacitySlider = document.getElementById('discreteModeOpacity') as HTMLInputElement;
 const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
+const toggleApiKeyBtn = document.getElementById('toggleApiKeyVisibility') as HTMLButtonElement;
 
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
 };
+
+// Icons
+const EYE_OPEN_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="20" height="20">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+  <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+</svg>
+`;
+
+const EYE_CLOSED_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="20" height="20">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
+</svg>
+`;
+
+toggleApiKeyBtn.addEventListener('click', () => {
+  const currentType = apiKeyInput.type;
+  if (currentType === 'password') {
+    apiKeyInput.type = 'text';
+    toggleApiKeyBtn.innerHTML = EYE_CLOSED_ICON;
+    toggleApiKeyBtn.setAttribute('aria-label', 'Hide API key');
+  } else {
+    apiKeyInput.type = 'password';
+    toggleApiKeyBtn.innerHTML = EYE_OPEN_ICON;
+    toggleApiKeyBtn.setAttribute('aria-label', 'Show API key');
+  }
+});
 
 function updateModelDropdown(models: string[], selectedModel: string) {
   modelSelect.innerHTML = '';

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -83,6 +83,39 @@ select:focus {
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #9ca3af;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s;
+}
+
+.toggle-password-btn:hover {
+  color: #4b5563;
+}
+
+.toggle-password-btn:focus {
+  outline: none;
+  color: #3b82f6;
+}
+
 small {
   display: block;
   margin-top: 4px;


### PR DESCRIPTION
💡 What: Added a toggle button inside the API Key input field to switch visibility between password (masked) and text (visible).
🎯 Why: Users need to verify they have pasted the correct API key without keeping it permanently visible.
♿ Accessibility: Added aria-label="Show API key" / "Hide API key" to the toggle button, ensuring screen reader support.

---
*PR created automatically by Jules for task [12777383733220826440](https://jules.google.com/task/12777383733220826440) started by @devin201o*