### PR TITLE
🎨 Palette: Add password visibility toggle to API key field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@types/chrome": "^0.0.268",
+    "@types/jsdom": "^27.0.0",
     "jsdom": "^27.0.0",
     "typescript": "^5.3.3",
     "vite": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@types/chrome':
         specifier: ^0.0.268
         version: 0.0.268
+      '@types/jsdom':
+        specifier: ^27.0.0
+        version: 27.0.0
       jsdom:
         specifier: ^27.0.0
         version: 27.4.0
@@ -19,13 +22,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^5.0.0
-        version: 5.4.21
+        version: 5.4.21(@types/node@25.2.3)
       vite-plugin-static-copy:
         specifier: ^3.1.3
-        version: 3.2.0(vite@5.4.21)
+        version: 3.2.0(vite@5.4.21(@types/node@25.2.3))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(jsdom@27.4.0)
+        version: 3.2.4(@types/node@25.2.3)(jsdom@27.4.0)
 
 packages:
 
@@ -368,6 +371,15 @@ packages:
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
+  '@types/jsdom@27.0.0':
+    resolution: {integrity: sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -577,6 +589,9 @@ packages:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
@@ -687,6 +702,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1016,6 +1034,18 @@ snapshots:
 
   '@types/har-format@1.2.16': {}
 
+  '@types/jsdom@27.0.0':
+    dependencies:
+      '@types/node': 25.2.3
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@types/tough-cookie@4.0.5': {}
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -1024,13 +1054,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.21)':
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@25.2.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.2.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1259,6 +1289,10 @@ snapshots:
 
   p-map@7.0.4: {}
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
@@ -1371,13 +1405,15 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  vite-node@3.2.4:
+  undici-types@7.16.0: {}
+
+  vite-node@3.2.4(@types/node@25.2.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.2.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -1389,27 +1425,28 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-static-copy@3.2.0(vite@5.4.21):
+  vite-plugin-static-copy@3.2.0(vite@5.4.21(@types/node@25.2.3)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.4
       picocolors: 1.1.1
       tinyglobby: 0.2.15
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.2.3)
 
-  vite@5.4.21:
+  vite@5.4.21(@types/node@25.2.3):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.57.1
     optionalDependencies:
+      '@types/node': 25.2.3
       fsevents: 2.3.3
 
-  vitest@3.2.4(jsdom@27.4.0):
+  vitest@3.2.4(@types/node@25.2.3)(jsdom@27.4.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.21)
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@25.2.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1427,10 +1464,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.21
-      vite-node: 3.2.4
+      vite: 5.4.21(@types/node@25.2.3)
+      vite-node: 3.2.4(@types/node@25.2.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 25.2.3
       jsdom: 27.4.0
     transitivePeerDependencies:
       - less

--- a/src/background.ts
+++ b/src/background.ts
@@ -246,7 +246,7 @@ async function updateContextMenu() {
 }
 
 async function pingTab(tabId: number): Promise<boolean> {
-  let timeout: NodeJS.Timeout;
+  let timeout: ReturnType<typeof setTimeout>;
   return new Promise((resolve) => {
     timeout = setTimeout(() => {
       console.log(`Ping timeout for tab ${tabId}`);

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,19 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" id="toggleApiKeyBtn" class="toggle-password-btn" aria-label="Show API Key">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye"><path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/></svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,6 +21,7 @@ const discreteModeToggle = document.getElementById('discreteMode') as HTMLInputE
 const opacityGroup = document.getElementById('opacityGroup') as HTMLDivElement;
 const opacitySlider = document.getElementById('discreteModeOpacity') as HTMLInputElement;
 const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
+const toggleApiKeyBtn = document.getElementById('toggleApiKeyBtn') as HTMLButtonElement;
 
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
@@ -216,6 +217,25 @@ function showStatus(message: string, type: 'success' | 'error' | 'info') {
   setTimeout(() => {
     statusDiv.classList.remove('show');
   }, 5000);
+}
+
+// Password toggle logic
+const EYE_ICON = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye"><path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/></svg>';
+const EYE_OFF_ICON = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye-off"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>';
+
+if (toggleApiKeyBtn) {
+  toggleApiKeyBtn.addEventListener('click', () => {
+    const type = apiKeyInput.getAttribute('type') === 'password' ? 'text' : 'password';
+    apiKeyInput.setAttribute('type', type);
+
+    if (type === 'text') {
+      toggleApiKeyBtn.innerHTML = EYE_OFF_ICON;
+      toggleApiKeyBtn.setAttribute('aria-label', 'Hide API Key');
+    } else {
+      toggleApiKeyBtn.innerHTML = EYE_ICON;
+      toggleApiKeyBtn.setAttribute('aria-label', 'Show API Key');
+    }
+  });
 }
 
 loadSettings();

--- a/src/options_toggle.test.ts
+++ b/src/options_toggle.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock chrome API
+const mockChrome = {
+  storage: {
+    local: {
+      get: vi.fn().mockResolvedValue({}),
+      set: vi.fn(),
+    },
+    onChanged: {
+      addListener: vi.fn(),
+    }
+  },
+  runtime: {
+    sendMessage: vi.fn(),
+  }
+};
+(globalThis as any).chrome = mockChrome;
+
+// Mock window.prompt
+(globalThis as any).prompt = vi.fn();
+
+describe('Password Toggle', () => {
+  beforeEach(() => {
+    // Set up a minimal DOM that satisfies options.ts requirements
+    document.body.innerHTML = `
+      <form id="settingsForm">
+        <input type="password" id="apiKey" />
+        <button type="button" id="toggleApiKeyBtn" aria-label="Show API Key"></button>
+
+        <select id="provider">
+            <option value="openrouter">OpenRouter</option>
+            <option value="custom">Custom</option>
+        </select>
+        <input id="apiEndpoint" />
+        <select id="model"></select>
+        <button id="addModelBtn"></button>
+        <button id="deleteModelBtn"></button>
+        <input id="maxTokens" value="100" />
+        <select id="toastPosition"></select>
+        <input id="toastDuration" value="5" />
+        <input type="checkbox" id="toastIndefinite" />
+        <button id="testBtn"></button>
+        <div id="status"></div>
+        <div id="endpointGroup"></div>
+
+        <input type="radio" name="promptMode" value="auto" checked>
+        <input type="radio" name="promptMode" value="manual">
+        <input type="radio" name="promptMode" value="custom">
+
+        <div id="customPromptContainer"></div>
+        <textarea id="customPrompt"></textarea>
+
+        <input type="checkbox" id="discreteMode" />
+        <div id="opacityGroup"></div>
+        <input id="discreteModeOpacity" value="0.5" />
+        <span id="opacityValue"></span>
+      </form>
+    `;
+
+    vi.resetModules();
+  });
+
+  it('should toggle password visibility and aria-label', async () => {
+    // Import the module to attach event listeners
+    // We need to ignore the promise returned by loadSettings if possible,
+    // or just let it run since we mocked chrome.storage.
+    await import('./options');
+
+    const input = document.getElementById('apiKey') as HTMLInputElement;
+    const btn = document.getElementById('toggleApiKeyBtn') as HTMLButtonElement;
+
+    // Initial state
+    expect(input.type).toBe('password');
+    expect(btn.getAttribute('aria-label')).toBe('Show API Key');
+
+    // Click to show
+    btn.click();
+
+    expect(input.type).toBe('text');
+    expect(btn.getAttribute('aria-label')).toBe('Hide API Key');
+    expect(btn.innerHTML).toContain('lucide-eye-off');
+
+    // Click to hide
+    btn.click();
+
+    expect(input.type).toBe('password');
+    expect(btn.getAttribute('aria-label')).toBe('Show API Key');
+    expect(btn.innerHTML).toContain('lucide-eye');
+  });
+});

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -258,3 +258,39 @@ input[type="range"] {
 .btn-icon:hover {
   background: #e5e7eb;
 }
+/* Password toggle styles */
+.input-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border-radius: 4px;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+  background-color: #f3f4f6;
+}
+
+.toggle-password-btn:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
💡 What: Added a password visibility toggle (show/hide) for the API key input field in the Options page.

🎯 Why: Users need to verify their API key without keeping it permanently visible for security reasons. This prevents typos and improves usability.

📸 Before/After: The API key field now has an eye icon on the right side. Clicking it reveals the text and changes the icon to an eye-slash.

♿ Accessibility: The toggle button includes a dynamic `aria-label` ("Show API Key" / "Hide API Key") and keyboard focus support.

---
*PR created automatically by Jules for task [2664021926772843258](https://jules.google.com/task/2664021926772843258) started by @devin201o*