### PR TITLE
🎨 Palette: Add visibility toggle for API Key input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - [API Key Visibility Toggle]
+**Learning:** Users often need to verify complex inputs like API keys without resetting them. Adding a show/hide toggle inside the input field is a standard pattern that improves usability and reduces errors.
+**Action:** When implementing password or API key fields, always consider adding a visibility toggle. Ensure it is accessible by using `aria-label` that updates dynamically (Show/Hide) and use semantic HTML (button type="button").

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,22 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" id="toggleApiKeyBtn" class="toggle-password-btn" aria-label="Show API key">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="20" height="20">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+              </svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,6 +3,7 @@ import { ExtensionSettings, DEFAULT_SETTINGS } from './types';
 const form = document.getElementById('settingsForm') as HTMLFormElement;
 const providerSelect = document.getElementById('provider') as HTMLSelectElement;
 const apiKeyInput = document.getElementById('apiKey') as HTMLInputElement;
+const toggleApiKeyBtn = document.getElementById('toggleApiKeyBtn') as HTMLButtonElement;
 const apiEndpointInput = document.getElementById('apiEndpoint') as HTMLInputElement;
 const modelSelect = document.getElementById('model') as HTMLSelectElement;
 const addModelBtn = document.getElementById('addModelBtn') as HTMLButtonElement;
@@ -217,5 +218,31 @@ function showStatus(message: string, type: 'success' | 'error' | 'info') {
     statusDiv.classList.remove('show');
   }, 5000);
 }
+
+toggleApiKeyBtn.addEventListener('click', () => {
+  const currentType = apiKeyInput.getAttribute('type');
+  const newType = currentType === 'password' ? 'text' : 'password';
+  apiKeyInput.setAttribute('type', newType);
+
+  const isPassword = newType === 'password';
+  toggleApiKeyBtn.setAttribute('aria-label', isPassword ? 'Show API key' : 'Hide API key');
+
+  // Eye icon
+  const showIcon = `
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="20" height="20">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+      <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+    </svg>
+  `;
+
+  // Eye slash icon
+  const hideIcon = `
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="20" height="20">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88" />
+    </svg>
+  `;
+
+  toggleApiKeyBtn.innerHTML = isPassword ? showIcon : hideIcon;
+});
 
 loadSettings();

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -258,3 +258,32 @@ input[type="range"] {
 .btn-icon:hover {
   background: #e5e7eb;
 }
+
+.input-wrapper {
+  position: relative;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.toggle-password-btn:hover {
+  background-color: #f3f4f6;
+  color: #374151;
+}
+
+#apiKey {
+  padding-right: 40px;
+}


### PR DESCRIPTION
💡 What: Added a "Show/Hide" toggle button to the API Key input field in the settings page.
🎯 Why: API keys are long and complex. Users often need to verify what they've pasted or typed without having to reset the field. This reduces errors and frustration.
📸 Before/After: (See verification screenshots)
♿ Accessibility: The button is keyboard accessible and uses dynamic `aria-label` ("Show API key" / "Hide API key") to inform screen reader users of the current state.


---
*PR created automatically by Jules for task [3182985528213490710](https://jules.google.com/task/3182985528213490710) started by @devin201o*