### PR TITLE
Add API Key Visibility Toggle

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,23 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" class="toggle-password-btn" id="toggleApiKeyBtn" aria-label="Show API Key">
+              <!-- Eye Icon (Show) -->
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="20" height="20">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+              </svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,6 +21,20 @@ const discreteModeToggle = document.getElementById('discreteMode') as HTMLInputE
 const opacityGroup = document.getElementById('opacityGroup') as HTMLDivElement;
 const opacitySlider = document.getElementById('discreteModeOpacity') as HTMLInputElement;
 const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
+const toggleApiKeyBtn = document.getElementById('toggleApiKeyBtn') as HTMLButtonElement;
+
+const EYE_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="20" height="20">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+  <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+</svg>
+`;
+
+const EYE_SLASH_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="20" height="20">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88" />
+</svg>
+`;
 
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
@@ -217,5 +231,12 @@ function showStatus(message: string, type: 'success' | 'error' | 'info') {
     statusDiv.classList.remove('show');
   }, 5000);
 }
+
+toggleApiKeyBtn.addEventListener('click', () => {
+  const isPassword = apiKeyInput.type === 'password';
+  apiKeyInput.type = isPassword ? 'text' : 'password';
+  toggleApiKeyBtn.innerHTML = isPassword ? EYE_SLASH_ICON : EYE_ICON;
+  toggleApiKeyBtn.ariaLabel = isPassword ? 'Hide API Key' : 'Show API Key';
+});
 
 loadSettings();

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -258,3 +258,33 @@ input[type="range"] {
 .btn-icon:hover {
   background: #e5e7eb;
 }
+
+.input-wrapper {
+  position: relative;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+  background-color: #f3f4f6;
+}
+
+#apiKey {
+  padding-right: 40px;
+}


### PR DESCRIPTION
Added a "Show/Hide" toggle button to the API key input field in the settings page. This allows users to easily verify their API key entry without having to clear and re-type it. The implementation uses accessible button controls and updates the aria-label dynamically.

---
*PR created automatically by Jules for task [4100875632591727430](https://jules.google.com/task/4100875632591727430) started by @devin201o*