### PR TITLE
Add password visibility toggle to options page

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,22 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" class="toggle-password-btn" aria-label="Show password">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="eye-icon">
+                <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"></path>
+                <circle cx="12" cy="12" r="3"></circle>
+              </svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.test.ts
+++ b/src/options.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+// Mock the chrome API
+const chromeMock = {
+  storage: {
+    local: {
+      get: vi.fn().mockResolvedValue({ settings: {} }),
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+    onChanged: {
+      addListener: vi.fn(),
+    },
+  },
+  runtime: {
+    sendMessage: vi.fn(),
+  },
+};
+
+vi.stubGlobal('chrome', chromeMock);
+
+describe('Options Page Password Toggle', () => {
+  beforeEach(async () => {
+    // Set up a fresh DOM for each test
+    const dom = new JSDOM(`
+      <!DOCTYPE html>
+      <html>
+      <body>
+        <form id="settingsForm">
+          <div class="form-group">
+            <label for="apiKey">OpenRouter API Key</label>
+            <div class="input-wrapper">
+              <input type="password" id="apiKey" name="apiKey" />
+              <button type="button" class="toggle-password-btn" aria-label="Show password">
+                <svg class="eye-icon"></svg>
+              </button>
+            </div>
+          </div>
+
+          <!-- Other required elements to prevent options.ts from crashing -->
+          <select id="provider"><option value="openrouter">OpenRouter</option></select>
+          <input id="apiEndpoint" />
+          <div id="endpointGroup"></div>
+          <select id="model"></select>
+          <button id="addModelBtn"></button>
+          <button id="deleteModelBtn"></button>
+          <input id="maxTokens" />
+          <select id="toastPosition"></select>
+          <input id="toastDuration" />
+          <input id="toastIndefinite" type="checkbox" />
+          <input type="radio" name="promptMode" value="auto" checked />
+          <input type="radio" name="promptMode" value="manual" />
+          <input type="radio" name="promptMode" value="custom" />
+          <div id="customPromptContainer"></div>
+          <textarea id="customPrompt"></textarea>
+          <input id="discreteMode" type="checkbox" />
+          <div id="opacityGroup"></div>
+          <input id="discreteModeOpacity" type="range" />
+          <span id="opacityValue"></span>
+          <button id="testBtn"></button>
+          <div id="status"></div>
+        </form>
+      </body>
+      </html>
+    `);
+
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('HTMLInputElement', dom.window.HTMLInputElement);
+    vi.stubGlobal('HTMLSelectElement', dom.window.HTMLSelectElement);
+    vi.stubGlobal('HTMLButtonElement', dom.window.HTMLButtonElement);
+    vi.stubGlobal('HTMLFormElement', dom.window.HTMLFormElement);
+    vi.stubGlobal('HTMLDivElement', dom.window.HTMLDivElement);
+    vi.stubGlobal('HTMLTextAreaElement', dom.window.HTMLTextAreaElement);
+    vi.stubGlobal('HTMLSpanElement', dom.window.HTMLSpanElement);
+
+    // Reset mocks
+    chrome.storage.local.get.mockResolvedValue({ settings: {} });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('should toggle password visibility when button is clicked', async () => {
+    // Import the options script to initialize listeners
+    await import('./options.ts?v=' + Date.now());
+
+    const apiKeyInput = document.getElementById('apiKey') as HTMLInputElement;
+    const toggleBtn = document.querySelector('.toggle-password-btn') as HTMLButtonElement;
+
+    // Initial state
+    expect(apiKeyInput.type).toBe('password');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Show password');
+
+    // Click to show password
+    toggleBtn.click();
+    expect(apiKeyInput.type).toBe('text');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Hide password');
+
+    // Click to hide password
+    toggleBtn.click();
+    expect(apiKeyInput.type).toBe('password');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Show password');
+  });
+});

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,6 +21,22 @@ const discreteModeToggle = document.getElementById('discreteMode') as HTMLInputE
 const opacityGroup = document.getElementById('opacityGroup') as HTMLDivElement;
 const opacitySlider = document.getElementById('discreteModeOpacity') as HTMLInputElement;
 const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
+const togglePasswordBtn = document.querySelector('.toggle-password-btn') as HTMLButtonElement;
+
+if (togglePasswordBtn) {
+  togglePasswordBtn.addEventListener('click', () => {
+    const type = apiKeyInput.getAttribute('type') === 'password' ? 'text' : 'password';
+    apiKeyInput.setAttribute('type', type);
+
+    // Update icon
+    const icon = type === 'password'
+      ? `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="eye-icon"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"></path><circle cx="12" cy="12" r="3"></circle></svg>`
+      : `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="eye-off-icon"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"></path><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"></path><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"></path><line x1="2" x2="22" y1="2" y2="22"></line></svg>`;
+
+    togglePasswordBtn.innerHTML = icon;
+    togglePasswordBtn.setAttribute('aria-label', type === 'password' ? 'Show password' : 'Hide password');
+  });
+}
 
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -258,3 +258,39 @@ input[type="range"] {
 .btn-icon:hover {
   background: #e5e7eb;
 }
+
+/* Password toggle styles */
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border-radius: 4px;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+  background-color: #f3f4f6;
+}
+
+.toggle-password-btn:focus-visible {
+  outline: 2px solid #3b82f6;
+  border-radius: 4px;
+}


### PR DESCRIPTION
This change improves the UX of the options page by allowing users to toggle the visibility of the OpenRouter API key. This helps users verify their key without having to re-paste it. The implementation wraps the input field and adds a button that toggles the input type between `password` and `text`. It also updates the button icon and `aria-label` for accessibility.

---
*PR created automatically by Jules for task [8977110283051784180](https://jules.google.com/task/8977110283051784180) started by @devin201o*