### PR TITLE
🎨 Palette: Add password visibility toggle to API key input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-05-23 - Password Visibility Toggle
+**Learning:** Testing UI logic in top-level scripts (like `options.ts`) requires careful DOM mocking and module resetting. Using `JSDOM` to manually construct the expected DOM structure is cleaner than reading files when file I/O types are missing.
+**Action:** When adding interactive UI elements to extension pages, prefer manually mocking the required DOM elements in tests to avoid dependency on file system reads and types.
+
+## 2024-05-23 - Inline SVGs for UI Controls
+**Learning:** For simple UI controls like "show/hide password", inline SVGs are more maintainable than external assets as they don't require build configuration changes or asset copying.
+**Action:** Use inline SVGs for small, interactive icons within the code to keep components self-contained.

--- a/src/background.ts
+++ b/src/background.ts
@@ -246,7 +246,7 @@ async function updateContextMenu() {
 }
 
 async function pingTab(tabId: number): Promise<boolean> {
-  let timeout: NodeJS.Timeout;
+  let timeout: ReturnType<typeof setTimeout>;
   return new Promise((resolve) => {
     timeout = setTimeout(() => {
       console.log(`Ping timeout for tab ${tabId}`);

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,22 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" class="toggle-password-btn" aria-label="Show password">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+                <path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+              </svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.test.ts
+++ b/src/options.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+// Mock chrome API
+const chromeMock = {
+  storage: {
+    local: {
+      get: vi.fn().mockResolvedValue({ settings: {} }),
+      set: vi.fn(),
+    },
+    onChanged: {
+      addListener: vi.fn(),
+    },
+  },
+  runtime: {
+    sendMessage: vi.fn(),
+  },
+};
+
+vi.stubGlobal('chrome', chromeMock);
+
+// Stub prompt
+vi.stubGlobal('prompt', vi.fn());
+
+describe('Options Page Password Toggle', () => {
+  let dom: JSDOM;
+
+  beforeEach(async () => {
+    // Manually create the DOM structure expected by options.ts
+    // This avoids needing fs and reading the file
+    dom = new JSDOM(`
+      <!DOCTYPE html>
+      <html>
+        <body>
+          <form id="settingsForm">
+            <select id="provider"><option value="openrouter">OpenRouter</option></select>
+            <div class="input-wrapper">
+              <input type="password" id="apiKey" />
+              <button type="button" class="toggle-password-btn" aria-label="Show password"></button>
+            </div>
+            <input type="url" id="apiEndpoint" />
+            <select id="model"></select>
+            <button id="addModelBtn"></button>
+            <button id="deleteModelBtn"></button>
+            <input type="number" id="maxTokens" value="1000" />
+            <select id="toastPosition"></select>
+            <input type="number" id="toastDuration" value="5" />
+            <input type="checkbox" id="toastIndefinite" />
+            <button type="button" id="testBtn"></button>
+            <div id="status"></div>
+            <div id="endpointGroup"></div>
+            <input type="radio" name="promptMode" value="auto" checked />
+            <div id="customPromptContainer"></div>
+            <textarea id="customPrompt"></textarea>
+            <input type="checkbox" id="discreteMode" />
+            <div id="opacityGroup"></div>
+            <input type="range" id="discreteModeOpacity" />
+            <span id="opacityValue"></span>
+          </form>
+        </body>
+      </html>
+    `, {
+      url: 'http://localhost',
+    });
+
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('HTMLInputElement', dom.window.HTMLInputElement);
+    vi.stubGlobal('HTMLButtonElement', dom.window.HTMLButtonElement);
+    vi.stubGlobal('HTMLFormElement', dom.window.HTMLFormElement);
+    vi.stubGlobal('HTMLSelectElement', dom.window.HTMLSelectElement);
+    vi.stubGlobal('HTMLDivElement', dom.window.HTMLDivElement);
+    vi.stubGlobal('HTMLTextAreaElement', dom.window.HTMLTextAreaElement);
+    vi.stubGlobal('HTMLSpanElement', dom.window.HTMLSpanElement);
+
+    // Reset modules to re-execute the top-level code in options.ts
+    vi.resetModules();
+
+    // Import the options script
+    // We catch errors because options.ts might try to do things we haven't fully mocked
+    // but as long as it attaches the listener we care about, we're good.
+    try {
+      await import('./options.ts?v=' + Date.now());
+    } catch (e) {
+      console.error('Error importing options.ts', e);
+    }
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should toggle password visibility when button is clicked', () => {
+    const apiKeyInput = document.getElementById('apiKey') as HTMLInputElement;
+    const toggleBtn = document.querySelector('.toggle-password-btn') as HTMLButtonElement;
+
+    // Initial state
+    expect(apiKeyInput.type).toBe('password');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Show password');
+    // We can't easily check innerHTML for the SVG since we don't have the constants exported,
+    // but we can check if it changes or if we want to be precise, we can check the aria-label which is enough for a11y.
+
+    // Click to show password
+    toggleBtn.click();
+    expect(apiKeyInput.type).toBe('text');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Hide password');
+
+    // Click to hide password
+    toggleBtn.click();
+    expect(apiKeyInput.type).toBe('password');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Show password');
+  });
+});

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,6 +21,31 @@ const discreteModeToggle = document.getElementById('discreteMode') as HTMLInputE
 const opacityGroup = document.getElementById('opacityGroup') as HTMLDivElement;
 const opacitySlider = document.getElementById('discreteModeOpacity') as HTMLInputElement;
 const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
+const togglePasswordBtn = document.querySelector('.toggle-password-btn') as HTMLButtonElement;
+
+const EYE_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+  <path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+</svg>
+`;
+
+const EYE_OFF_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
+  <path d="M10.73 5.08A10.43 10.43 0 0 1 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+  <path d="M12 19.5c-4.638 0-8.573-3.007-9.963-7.178a1.012 1.012 0 0 1 0-.639c.288-.868.65-1.688 1.078-2.455" />
+  <path d="M2 2l20 20" />
+</svg>
+`;
+
+togglePasswordBtn.addEventListener('click', () => {
+  const type = apiKeyInput.getAttribute('type') === 'password' ? 'text' : 'password';
+  apiKeyInput.setAttribute('type', type);
+
+  togglePasswordBtn.innerHTML = type === 'password' ? EYE_ICON : EYE_OFF_ICON;
+  togglePasswordBtn.setAttribute('aria-label', type === 'password' ? 'Show password' : 'Hide password');
+});
 
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -258,3 +258,34 @@ input[type="range"] {
 .btn-icon:hover {
   background: #e5e7eb;
 }
+.input-wrapper {
+  position: relative;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  color: #6b7280;
+  transition: color 0.2s;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+}
+
+.toggle-password-btn:focus {
+  outline: none;
+  color: #3b82f6;
+}


### PR DESCRIPTION
This PR adds a password visibility toggle (show/hide) for the API key input in the options page. This is a common UX pattern that helps users verify their API keys without errors. It uses inline SVGs for the icons and includes a test to ensure the toggle works correctly. It also fixes a minor TypeScript error in the background script.

---
*PR created automatically by Jules for task [15000664225598652225](https://jules.google.com/task/15000664225598652225) started by @devin201o*