### PR TITLE
Add password visibility toggle to settings page

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-20 - Password Visibility Toggle Pattern
+**Learning:** Adding a show/hide toggle to password inputs significantly reduces user error, especially for long API keys. For accessibility, the button must be inside the input wrapper (visually), but not interfere with the input's text. Dynamically updating `aria-label` from "Show password" to "Hide password" is critical for screen reader users to know the current state and the action they are about to perform.
+**Action:** Use a relative `.input-wrapper` container with `padding-right` on the input equal to the button's width + spacing. Use an absolute positioned button with an SVG icon. Ensure `type="button"` to prevent form submission.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "devDependencies": {
     "@types/chrome": "^0.0.268",
+    "@types/jsdom": "^27.0.0",
+    "@types/node": "^25.3.0",
     "jsdom": "^27.0.0",
     "typescript": "^5.3.3",
     "vite": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@types/chrome':
         specifier: ^0.0.268
         version: 0.0.268
+      '@types/jsdom':
+        specifier: ^27.0.0
+        version: 27.0.0
+      '@types/node':
+        specifier: ^25.3.0
+        version: 25.3.0
       jsdom:
         specifier: ^27.0.0
         version: 27.4.0
@@ -19,13 +25,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^5.0.0
-        version: 5.4.21
+        version: 5.4.21(@types/node@25.3.0)
       vite-plugin-static-copy:
         specifier: ^3.1.3
-        version: 3.2.0(vite@5.4.21)
+        version: 3.2.0(vite@5.4.21(@types/node@25.3.0))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(jsdom@27.4.0)
+        version: 3.2.4(@types/node@25.3.0)(jsdom@27.4.0)
 
 packages:
 
@@ -368,6 +374,15 @@ packages:
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
+  '@types/jsdom@27.0.0':
+    resolution: {integrity: sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw==}
+
+  '@types/node@25.3.0':
+    resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -577,6 +592,9 @@ packages:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
@@ -687,6 +705,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1016,6 +1037,18 @@ snapshots:
 
   '@types/har-format@1.2.16': {}
 
+  '@types/jsdom@27.0.0':
+    dependencies:
+      '@types/node': 25.3.0
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+
+  '@types/node@25.3.0':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/tough-cookie@4.0.5': {}
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -1024,13 +1057,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.21)':
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@25.3.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.3.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1259,6 +1292,10 @@ snapshots:
 
   p-map@7.0.4: {}
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
@@ -1371,13 +1408,15 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  vite-node@3.2.4:
+  undici-types@7.18.2: {}
+
+  vite-node@3.2.4(@types/node@25.3.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.3.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -1389,27 +1428,28 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-static-copy@3.2.0(vite@5.4.21):
+  vite-plugin-static-copy@3.2.0(vite@5.4.21(@types/node@25.3.0)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.4
       picocolors: 1.1.1
       tinyglobby: 0.2.15
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.3.0)
 
-  vite@5.4.21:
+  vite@5.4.21(@types/node@25.3.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.57.1
     optionalDependencies:
+      '@types/node': 25.3.0
       fsevents: 2.3.3
 
-  vitest@3.2.4(jsdom@27.4.0):
+  vitest@3.2.4(@types/node@25.3.0)(jsdom@27.4.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.21)
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@25.3.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1427,10 +1467,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.21
-      vite-node: 3.2.4
+      vite: 5.4.21(@types/node@25.3.0)
+      vite-node: 3.2.4(@types/node@25.3.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 25.3.0
       jsdom: 27.4.0
     transitivePeerDependencies:
       - less

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,22 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" class="toggle-password-btn" aria-label="Show password">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
+                <path fill-rule="evenodd" d="M1.323 11.447C2.811 6.976 7.028 3.75 12.001 3.75c4.97 0 9.185 3.223 10.675 7.69.12.362.12.752 0 1.113-1.487 4.471-5.705 7.697-10.677 7.697-4.97 0-9.186-3.223-10.675-7.69a1.762 1.762 0 010-1.113zM17.25 12a5.25 5.25 0 11-10.5 0 5.25 5.25 0 0110.5 0z" clip-rule="evenodd" />
+              </svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.test.ts
+++ b/src/options.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Mock chrome global
+const chromeMock = {
+  storage: {
+    local: {
+      get: vi.fn().mockResolvedValue({ settings: {} }),
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+    onChanged: {
+      addListener: vi.fn(),
+    },
+  },
+  runtime: {
+    sendMessage: vi.fn(),
+  },
+};
+
+vi.stubGlobal('chrome', chromeMock);
+
+// We need to read the HTML file content
+const htmlContent = fs.readFileSync(path.resolve(process.cwd(), 'src/options.html'), 'utf8');
+
+describe('Options Page', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+
+    // Mock console.error to suppress JSDOM CSS errors
+    const originalConsoleError = console.error;
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (typeof args[0] === 'string' && args[0].includes('Could not load link')) return;
+      originalConsoleError(...args);
+    });
+
+    const dom = new JSDOM(htmlContent, {
+      url: 'http://localhost/',
+      runScripts: 'dangerously',
+      resources: 'usable',
+    });
+
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('navigator', dom.window.navigator);
+    vi.stubGlobal('prompt', vi.fn());
+
+    // Stub other global objects needed by the script
+    vi.stubGlobal('HTMLFormElement', dom.window.HTMLFormElement);
+    vi.stubGlobal('HTMLSelectElement', dom.window.HTMLSelectElement);
+    vi.stubGlobal('HTMLInputElement', dom.window.HTMLInputElement);
+    vi.stubGlobal('HTMLButtonElement', dom.window.HTMLButtonElement);
+    vi.stubGlobal('HTMLDivElement', dom.window.HTMLDivElement);
+    vi.stubGlobal('HTMLTextAreaElement', dom.window.HTMLTextAreaElement);
+    vi.stubGlobal('HTMLSpanElement', dom.window.HTMLSpanElement);
+
+    // Attempt to re-import the module
+    // We use a variable to avoid static analysis errors with template literals in import()
+    // if that was the cause.
+    try {
+      await import('./options');
+    } catch (e) {
+      // If it fails, maybe because of path resolution in test env
+      console.error("Failed to import options:", e);
+    }
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('should toggle password visibility when button is clicked', async () => {
+    // Re-query elements from the new DOM
+    const apiKeyInput = document.getElementById('apiKey') as HTMLInputElement;
+    const toggleBtn = document.querySelector('.toggle-password-btn') as HTMLButtonElement;
+
+    expect(apiKeyInput).not.toBeNull();
+    expect(toggleBtn).not.toBeNull();
+
+    // Initial state
+    expect(apiKeyInput.type).toBe('password');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Show password');
+
+    // Click to show
+    toggleBtn.click();
+    expect(apiKeyInput.type).toBe('text');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Hide password');
+
+    // Click to hide
+    toggleBtn.click();
+    expect(apiKeyInput.type).toBe('password');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Show password');
+  });
+});

--- a/src/options.ts
+++ b/src/options.ts
@@ -218,4 +218,29 @@ function showStatus(message: string, type: 'success' | 'error' | 'info') {
   }, 5000);
 }
 
+// Password toggle functionality
+const togglePasswordBtn = document.querySelector('.toggle-password-btn') as HTMLButtonElement;
+const EYE_ICON = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
+    <path fill-rule="evenodd" d="M1.323 11.447C2.811 6.976 7.028 3.75 12.001 3.75c4.97 0 9.185 3.223 10.675 7.69.12.362.12.752 0 1.113-1.487 4.471-5.705 7.697-10.677 7.697-4.97 0-9.186-3.223-10.675-7.69a1.762 1.762 0 010-1.113zM17.25 12a5.25 5.25 0 11-10.5 0 5.25 5.25 0 0110.5 0z" clip-rule="evenodd" />
+  </svg>
+`;
+const EYE_SLASH_ICON = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <path fill-rule="evenodd" d="M3.53 2.47a.75.75 0 00-1.06 1.06l18 18a.75.75 0 101.06-1.06l-18-18zM22.676 12.553a11.249 11.249 0 01-2.631 4.31l-3.099-3.099a5.25 5.25 0 00-6.71-6.71L7.759 4.577a11.217 11.217 0 014.242-.827c4.97 0 9.185 3.223 10.675 7.69.12.362.12.752 0 1.113z" clip-rule="evenodd" />
+    <path d="M5.535 5.535l5.015 5.015a3 3 0 104.242 4.242l1.986 1.986a11.255 11.255 0 01-5.897 1.126c-4.97 0-9.186-3.223-10.675-7.69a1.766 1.766 0 010-1.113 11.258 11.258 0 011.33-2.566z" />
+  </svg>
+`;
+
+if (togglePasswordBtn) {
+  togglePasswordBtn.addEventListener('click', () => {
+    const isPassword = apiKeyInput.type === 'password';
+
+    apiKeyInput.type = isPassword ? 'text' : 'password';
+    togglePasswordBtn.setAttribute('aria-label', isPassword ? 'Hide password' : 'Show password');
+    togglePasswordBtn.innerHTML = isPassword ? EYE_SLASH_ICON : EYE_ICON;
+  });
+}
+
 loadSettings();

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -258,3 +258,42 @@ input[type="range"] {
 .btn-icon:hover {
   background: #e5e7eb;
 }
+
+/* Password Toggle Styles */
+.input-wrapper {
+  position: relative;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  color: #6b7280;
+  transition: color 0.2s;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+}
+
+.toggle-password-btn:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.toggle-password-btn svg {
+  width: 20px;
+  height: 20px;
+}


### PR DESCRIPTION
💡 What: Added a password visibility toggle to the OpenRouter API Key input field in the settings page.
🎯 Why: API keys are long and complex strings. Users often make typos when entering them. Being able to see the key helps prevent errors and verify the input.
📸 Before/After: The input is now wrapped in a container with an eye icon button on the right. Clicking it reveals/masks the password.
♿ Accessibility: The button uses `aria-label` which updates dynamically between "Show password" and "Hide password" based on the state. The button is keyboard accessible.

---
*PR created automatically by Jules for task [13976710087623704939](https://jules.google.com/task/13976710087623704939) started by @devin201o*