### PR TITLE
🎨 Palette: Add password visibility toggle to API Key input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-05-22 - Testing Options Pages with Playwright
+
+**Learning:** When testing Chrome extension options pages with Playwright, serving the `dist` folder via `python3 -m http.server` and injecting a mock `window.chrome` object via `page.add_init_script` is a robust way to bypass the lack of extension APIs in a standard browser context. This allows verifying UI interactions that depend on storage or runtime messages without needing to load the full extension.
+
+**Action:** Use this pattern for future UI verifications of extension pages.

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,22 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" id="togglePasswordBtn" class="toggle-password-btn" aria-label="Show API Key">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                <circle cx="12" cy="12" r="3"></circle>
+              </svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,6 +3,7 @@ import { ExtensionSettings, DEFAULT_SETTINGS } from './types';
 const form = document.getElementById('settingsForm') as HTMLFormElement;
 const providerSelect = document.getElementById('provider') as HTMLSelectElement;
 const apiKeyInput = document.getElementById('apiKey') as HTMLInputElement;
+const togglePasswordBtn = document.getElementById('togglePasswordBtn') as HTMLButtonElement;
 const apiEndpointInput = document.getElementById('apiEndpoint') as HTMLInputElement;
 const modelSelect = document.getElementById('model') as HTMLSelectElement;
 const addModelBtn = document.getElementById('addModelBtn') as HTMLButtonElement;
@@ -217,5 +218,28 @@ function showStatus(message: string, type: 'success' | 'error' | 'info') {
     statusDiv.classList.remove('show');
   }, 5000);
 }
+
+togglePasswordBtn.addEventListener('click', () => {
+  const type = apiKeyInput.getAttribute('type') === 'password' ? 'text' : 'password';
+  apiKeyInput.setAttribute('type', type);
+
+  if (type === 'text') {
+    togglePasswordBtn.setAttribute('aria-label', 'Hide API Key');
+    togglePasswordBtn.innerHTML = `
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
+        <line x1="1" y1="1" x2="23" y2="23"></line>
+      </svg>
+    `;
+  } else {
+    togglePasswordBtn.setAttribute('aria-label', 'Show API Key');
+    togglePasswordBtn.innerHTML = `
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+        <circle cx="12" cy="12" r="3"></circle>
+      </svg>
+    `;
+  }
+});
 
 loadSettings();

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -258,3 +258,37 @@ input[type="range"] {
 .btn-icon:hover {
   background: #e5e7eb;
 }
+
+.input-wrapper {
+  position: relative;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.toggle-password-btn:hover {
+  background-color: #f3f4f6;
+  color: #374151;
+}
+
+.toggle-password-btn svg {
+  width: 20px;
+  height: 20px;
+}


### PR DESCRIPTION
💡 **What:** Added a show/hide toggle button to the OpenRouter API Key input in the settings page.
🎯 **Why:** Users need to verify their API key without clearing it or inspecting the DOM. This reduces friction and improves usability.
♿ **Accessibility:** The toggle button includes dynamic `aria-label` updates ("Show API Key" / "Hide API Key") and uses an accessible icon pattern.
📸 **Changes:**
    *   Wrapped the input in a relative container.
    *   Added an absolute positioned toggle button with SVG icon.
    *   Implemented toggle logic in `options.ts`.

---
*PR created automatically by Jules for task [15356707542659428140](https://jules.google.com/task/15356707542659428140) started by @devin201o*