### PR TITLE
🎨 Palette: Add password visibility toggle to API key input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Password Visibility Toggle Pattern
+**Learning:** For password fields, wrapping the input in a `.input-wrapper` and using an absolute positioned button with an inline SVG icon provides an accessible and standard UX.
+**Action:** Use this pattern for any new password or API key inputs. Ensure the input has `padding-right` to prevent text overlap.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@types/chrome": "^0.0.268",
+    "@types/jsdom": "^28.0.0",
     "jsdom": "^27.0.0",
     "typescript": "^5.3.3",
     "vite": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@types/chrome':
         specifier: ^0.0.268
         version: 0.0.268
+      '@types/jsdom':
+        specifier: ^28.0.0
+        version: 28.0.0
       jsdom:
         specifier: ^27.0.0
         version: 27.4.0
@@ -19,13 +22,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^5.0.0
-        version: 5.4.21
+        version: 5.4.21(@types/node@25.3.0)
       vite-plugin-static-copy:
         specifier: ^3.1.3
-        version: 3.2.0(vite@5.4.21)
+        version: 3.2.0(vite@5.4.21(@types/node@25.3.0))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(jsdom@27.4.0)
+        version: 3.2.4(@types/node@25.3.0)(jsdom@27.4.0)
 
 packages:
 
@@ -368,6 +371,15 @@ packages:
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
+  '@types/jsdom@28.0.0':
+    resolution: {integrity: sha512-A8TBQQC/xAOojy9kM8E46cqT00sF0h7dWjV8t8BJhUi2rG6JRh7XXQo/oLoENuZIQEpXsxLccLCnknyQd7qssQ==}
+
+  '@types/node@25.3.0':
+    resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -577,6 +589,9 @@ packages:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
@@ -687,6 +702,12 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici-types@7.22.0:
+    resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1016,6 +1037,19 @@ snapshots:
 
   '@types/har-format@1.2.16': {}
 
+  '@types/jsdom@28.0.0':
+    dependencies:
+      '@types/node': 25.3.0
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+      undici-types: 7.22.0
+
+  '@types/node@25.3.0':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/tough-cookie@4.0.5': {}
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -1024,13 +1058,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.21)':
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@25.3.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.3.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1259,6 +1293,10 @@ snapshots:
 
   p-map@7.0.4: {}
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
@@ -1371,13 +1409,17 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  vite-node@3.2.4:
+  undici-types@7.18.2: {}
+
+  undici-types@7.22.0: {}
+
+  vite-node@3.2.4(@types/node@25.3.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.3.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -1389,27 +1431,28 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-static-copy@3.2.0(vite@5.4.21):
+  vite-plugin-static-copy@3.2.0(vite@5.4.21(@types/node@25.3.0)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.4
       picocolors: 1.1.1
       tinyglobby: 0.2.15
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.3.0)
 
-  vite@5.4.21:
+  vite@5.4.21(@types/node@25.3.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.57.1
     optionalDependencies:
+      '@types/node': 25.3.0
       fsevents: 2.3.3
 
-  vitest@3.2.4(jsdom@27.4.0):
+  vitest@3.2.4(@types/node@25.3.0)(jsdom@27.4.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.21)
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@25.3.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1427,10 +1470,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.21
-      vite-node: 3.2.4
+      vite: 5.4.21(@types/node@25.3.0)
+      vite-node: 3.2.4(@types/node@25.3.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 25.3.0
       jsdom: 27.4.0
     transitivePeerDependencies:
       - less

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,22 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" class="toggle-password-btn" aria-label="Show password">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
+                <path fill-rule="evenodd" d="M1.323 11.447C2.811 6.976 7.028 3.75 12.001 3.75c4.97 0 9.185 3.223 10.675 7.69.12.362.12.752 0 1.113-1.487 4.471-5.705 7.697-10.677 7.697-4.97 0-9.186-3.223-10.675-7.69a1.762 1.762 0 010-1.113zM17.25 12a5.25 5.25 0 11-10.5 0 5.25 5.25 0 0110.5 0z" clip-rule="evenodd" />
+              </svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.test.ts
+++ b/src/options.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+// Mock chrome global
+const chromeMock = {
+  storage: {
+    local: {
+      get: vi.fn().mockResolvedValue({ settings: {} }),
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+    onChanged: {
+      addListener: vi.fn(),
+    },
+  },
+  runtime: {
+    sendMessage: vi.fn(),
+  },
+};
+
+vi.stubGlobal('chrome', chromeMock);
+
+describe('Options Page Password Toggle', () => {
+  beforeEach(() => {
+    const dom = new JSDOM(`
+      <!DOCTYPE html>
+      <html>
+        <body>
+          <form id="settingsForm">
+            <select id="provider"><option value="openrouter">OpenRouter</option></select>
+            <div class="input-wrapper">
+                <input id="apiKey" type="password" />
+                <button class="toggle-password-btn" aria-label="Show password"></button>
+            </div>
+            <input id="apiEndpoint" />
+            <select id="model"></select>
+            <button id="addModelBtn"></button>
+            <button id="deleteModelBtn"></button>
+            <input id="maxTokens" />
+            <select id="toastPosition"></select>
+            <input id="toastDuration" />
+            <input id="toastIndefinite" type="checkbox" />
+            <button id="testBtn"></button>
+            <div id="status"></div>
+            <div id="endpointGroup"></div>
+            <input name="promptMode" value="auto" type="radio" />
+            <input name="promptMode" value="manual" type="radio" />
+            <input name="promptMode" value="custom" type="radio" />
+            <div id="customPromptContainer"></div>
+            <textarea id="customPrompt"></textarea>
+            <input id="discreteMode" type="checkbox" />
+            <div id="opacityGroup"></div>
+            <input id="discreteModeOpacity" />
+            <span id="opacityValue"></span>
+          </form>
+        </body>
+      </html>
+    `);
+
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('HTMLFormElement', dom.window.HTMLFormElement);
+    vi.stubGlobal('HTMLSelectElement', dom.window.HTMLSelectElement);
+    vi.stubGlobal('HTMLInputElement', dom.window.HTMLInputElement);
+    vi.stubGlobal('HTMLButtonElement', dom.window.HTMLButtonElement);
+    vi.stubGlobal('HTMLDivElement', dom.window.HTMLDivElement);
+    vi.stubGlobal('HTMLTextAreaElement', dom.window.HTMLTextAreaElement);
+    vi.stubGlobal('HTMLSpanElement', dom.window.HTMLSpanElement);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('should toggle password visibility when button is clicked', async () => {
+    // Import the module to attach listeners
+    await import('./options');
+
+    const apiKeyInput = document.getElementById('apiKey') as HTMLInputElement;
+    const toggleBtn = document.querySelector('.toggle-password-btn') as HTMLButtonElement;
+
+    expect(apiKeyInput.type).toBe('password');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Show password');
+
+    // Click to show password
+    toggleBtn.dispatchEvent(new window.Event('click'));
+    expect(apiKeyInput.type).toBe('text');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Hide password');
+
+    // Click to hide password
+    toggleBtn.dispatchEvent(new window.Event('click'));
+    expect(apiKeyInput.type).toBe('password');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Show password');
+  });
+});

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,6 +21,19 @@ const discreteModeToggle = document.getElementById('discreteMode') as HTMLInputE
 const opacityGroup = document.getElementById('opacityGroup') as HTMLDivElement;
 const opacitySlider = document.getElementById('discreteModeOpacity') as HTMLInputElement;
 const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
+const togglePasswordBtn = document.querySelector('.toggle-password-btn') as HTMLButtonElement;
+
+const EYE_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
+  <path fill-rule="evenodd" d="M1.323 11.447C2.811 6.976 7.028 3.75 12.001 3.75c4.97 0 9.185 3.223 10.675 7.69.12.362.12.752 0 1.113-1.487 4.471-5.705 7.697-10.677 7.697-4.97 0-9.186-3.223-10.675-7.69a1.762 1.762 0 010-1.113zM17.25 12a5.25 5.25 0 11-10.5 0 5.25 5.25 0 0110.5 0z" clip-rule="evenodd" />
+</svg>`;
+
+const EYE_SLASH_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M3.53 2.47a.75.75 0 00-1.06 1.06l18 18a.75.75 0 101.06-1.06l-18-18zM22.676 12.553a11.249 11.249 0 01-2.631 4.31l-3.099-3.099a5.25 5.25 0 00-6.71-6.71L7.759 4.577a11.217 11.217 0 014.242-.827c4.97 0 9.185 3.223 10.675 7.69.12.362.12.752 0 1.113z" />
+  <path d="M5.535 7.656A11.27 11.27 0 001.323 11.447c.12.362.12.752 0 1.113 1.487 4.471 5.705 7.697 10.677 7.697 2.27 0 4.395-.67 6.191-1.834l-2.772-2.772a5.25 5.25 0 01-6.71-6.71L5.535 7.656z" />
+</svg>`;
 
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
@@ -106,6 +119,19 @@ discreteModeToggle.addEventListener('change', updateOpacityGroupVisibility);
 
 opacitySlider.addEventListener('input', () => {
   opacityValue.textContent = opacitySlider.value;
+});
+
+togglePasswordBtn.addEventListener('click', () => {
+  const type = apiKeyInput.getAttribute('type') === 'password' ? 'text' : 'password';
+  apiKeyInput.setAttribute('type', type);
+
+  if (type === 'text') {
+    togglePasswordBtn.innerHTML = EYE_SLASH_ICON;
+    togglePasswordBtn.setAttribute('aria-label', 'Hide password');
+  } else {
+    togglePasswordBtn.innerHTML = EYE_ICON;
+    togglePasswordBtn.setAttribute('aria-label', 'Show password');
+  }
 });
 
 addModelBtn.addEventListener('click', async () => {

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -258,3 +258,36 @@ input[type="range"] {
 .btn-icon:hover {
   background: #e5e7eb;
 }
+
+/* Password Toggle */
+.input-wrapper {
+  position: relative;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  color: #6b7280;
+  transition: color 0.2s;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+}
+
+.toggle-password-btn svg {
+  width: 20px;
+  height: 20px;
+}


### PR DESCRIPTION
💡 What: Added a toggle button with an eye icon to the OpenRouter API Key input in the options page.
🎯 Why: To allow users to verify their API key while typing or pasting, preventing errors.
📸 Before/After: The password field now has an "eye" icon button inside it.
♿ Accessibility: The button has a dynamic `aria-label` ("Show password" / "Hide password") and uses semantic HTML.

---
*PR created automatically by Jules for task [10382523589917599357](https://jules.google.com/task/10382523589917599357) started by @devin201o*