### PR TITLE
🎨 Palette: Add password toggle to API key field

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-26 - Playwright Testing of Extension Pages
+**Learning:** To verify extension pages (like `options.html`) with Playwright in a standalone environment (without loading the full extension), inject a mock `window.chrome` object using `page.add_init_script`. This mock should stub necessary APIs like `storage.local` and `runtime.sendMessage` to prevent runtime errors.
+**Action:** Use `page.add_init_script` to inject mocks for verify scripts.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@types/chrome": "^0.0.268",
+    "@types/jsdom": "^28.0.0",
     "jsdom": "^27.0.0",
     "typescript": "^5.3.3",
     "vite": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@types/chrome':
         specifier: ^0.0.268
         version: 0.0.268
+      '@types/jsdom':
+        specifier: ^28.0.0
+        version: 28.0.0
       jsdom:
         specifier: ^27.0.0
         version: 27.4.0
@@ -19,13 +22,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^5.0.0
-        version: 5.4.21
+        version: 5.4.21(@types/node@25.3.1)
       vite-plugin-static-copy:
         specifier: ^3.1.3
-        version: 3.2.0(vite@5.4.21)
+        version: 3.2.0(vite@5.4.21(@types/node@25.3.1))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(jsdom@27.4.0)
+        version: 3.2.4(@types/node@25.3.1)(jsdom@27.4.0)
 
 packages:
 
@@ -368,6 +371,15 @@ packages:
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
+  '@types/jsdom@28.0.0':
+    resolution: {integrity: sha512-A8TBQQC/xAOojy9kM8E46cqT00sF0h7dWjV8t8BJhUi2rG6JRh7XXQo/oLoENuZIQEpXsxLccLCnknyQd7qssQ==}
+
+  '@types/node@25.3.1':
+    resolution: {integrity: sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -577,6 +589,9 @@ packages:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
@@ -687,6 +702,12 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici-types@7.22.0:
+    resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1016,6 +1037,19 @@ snapshots:
 
   '@types/har-format@1.2.16': {}
 
+  '@types/jsdom@28.0.0':
+    dependencies:
+      '@types/node': 25.3.1
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+      undici-types: 7.22.0
+
+  '@types/node@25.3.1':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/tough-cookie@4.0.5': {}
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -1024,13 +1058,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.21)':
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@25.3.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.3.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1259,6 +1293,10 @@ snapshots:
 
   p-map@7.0.4: {}
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
@@ -1371,13 +1409,17 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  vite-node@3.2.4:
+  undici-types@7.18.2: {}
+
+  undici-types@7.22.0: {}
+
+  vite-node@3.2.4(@types/node@25.3.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.3.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -1389,27 +1431,28 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-static-copy@3.2.0(vite@5.4.21):
+  vite-plugin-static-copy@3.2.0(vite@5.4.21(@types/node@25.3.1)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.4
       picocolors: 1.1.1
       tinyglobby: 0.2.15
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.3.1)
 
-  vite@5.4.21:
+  vite@5.4.21(@types/node@25.3.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.57.1
     optionalDependencies:
+      '@types/node': 25.3.1
       fsevents: 2.3.3
 
-  vitest@3.2.4(jsdom@27.4.0):
+  vitest@3.2.4(@types/node@25.3.1)(jsdom@27.4.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.21)
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@25.3.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1427,10 +1470,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.21
-      vite-node: 3.2.4
+      vite: 5.4.21(@types/node@25.3.1)
+      vite-node: 3.2.4(@types/node@25.3.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 25.3.1
       jsdom: 27.4.0
     transitivePeerDependencies:
       - less

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,23 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" id="toggleApiKeyBtn" class="toggle-password-btn" aria-label="Show API Key">
+              <!-- Eye Icon -->
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                <circle cx="12" cy="12" r="3"></circle>
+              </svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.test.ts
+++ b/src/options.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+// Mock chrome
+const chromeMock = {
+  storage: {
+    local: {
+      get: vi.fn().mockResolvedValue({ settings: {} }),
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+    onChanged: {
+      addListener: vi.fn(),
+    },
+  },
+  runtime: {
+    sendMessage: vi.fn(),
+  },
+};
+
+vi.stubGlobal('chrome', chromeMock);
+
+// Simplified HTML content containing all necessary IDs
+const OPTIONS_HTML = `
+<!DOCTYPE html>
+<html>
+<body>
+  <form id="settingsForm">
+    <select id="provider"><option value="openrouter">OpenRouter</option></select>
+
+    <div class="input-wrapper">
+      <input type="password" id="apiKey" />
+      <button type="button" id="toggleApiKeyBtn" aria-label="Show API Key"></button>
+    </div>
+
+    <input id="apiEndpoint" />
+    <select id="model"></select>
+    <button id="addModelBtn"></button>
+    <button id="deleteModelBtn"></button>
+    <input id="maxTokens" />
+    <select id="toastPosition"></select>
+    <input id="toastDuration" />
+    <input type="checkbox" id="toastIndefinite" />
+    <input type="radio" name="promptMode" value="auto" />
+    <input type="radio" name="promptMode" value="manual" />
+    <input type="radio" name="promptMode" value="custom" />
+    <div id="customPromptContainer"></div>
+    <textarea id="customPrompt"></textarea>
+    <input type="checkbox" id="discreteMode" />
+    <div id="opacityGroup"></div>
+    <input id="discreteModeOpacity" type="range" />
+    <span id="opacityValue"></span>
+    <div id="endpointGroup"></div>
+    <button type="submit"></button>
+    <button type="button" id="testBtn"></button>
+    <div id="status"></div>
+  </form>
+</body>
+</html>
+`;
+
+describe('Options Page', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+
+    const dom = new JSDOM(OPTIONS_HTML);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('prompt', vi.fn());
+
+    // We need to wait for the module to load
+    await import('./options.ts?v=' + Date.now());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should toggle password visibility when button is clicked', () => {
+    const apiKeyInput = document.getElementById('apiKey') as HTMLInputElement;
+    const toggleBtn = document.getElementById('toggleApiKeyBtn') as HTMLButtonElement;
+
+    // Initial state
+    expect(apiKeyInput.getAttribute('type')).toBe('password');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Show API Key');
+
+    // Click to show password
+    toggleBtn.click();
+    expect(apiKeyInput.getAttribute('type')).toBe('text');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Hide API Key');
+
+    // Click to hide password
+    toggleBtn.click();
+    expect(apiKeyInput.getAttribute('type')).toBe('password');
+    expect(toggleBtn.getAttribute('aria-label')).toBe('Show API Key');
+  });
+});

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,6 +3,7 @@ import { ExtensionSettings, DEFAULT_SETTINGS } from './types';
 const form = document.getElementById('settingsForm') as HTMLFormElement;
 const providerSelect = document.getElementById('provider') as HTMLSelectElement;
 const apiKeyInput = document.getElementById('apiKey') as HTMLInputElement;
+const toggleApiKeyBtn = document.getElementById('toggleApiKeyBtn') as HTMLButtonElement;
 const apiEndpointInput = document.getElementById('apiEndpoint') as HTMLInputElement;
 const modelSelect = document.getElementById('model') as HTMLSelectElement;
 const addModelBtn = document.getElementById('addModelBtn') as HTMLButtonElement;
@@ -85,6 +86,31 @@ function updateCustomPromptVisibility() {
 
 promptModeRadios.forEach(radio => {
   radio.addEventListener('change', updateCustomPromptVisibility);
+});
+
+toggleApiKeyBtn.addEventListener('click', () => {
+  const type = apiKeyInput.getAttribute('type') === 'password' ? 'text' : 'password';
+  apiKeyInput.setAttribute('type', type);
+
+  if (type === 'text') {
+    // Show eye-off icon
+    toggleApiKeyBtn.innerHTML = `
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
+        <line x1="1" y1="1" x2="23" y2="23"></line>
+      </svg>
+    `;
+    toggleApiKeyBtn.ariaLabel = 'Hide API Key';
+  } else {
+    // Show eye icon
+    toggleApiKeyBtn.innerHTML = `
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+        <circle cx="12" cy="12" r="3"></circle>
+      </svg>
+    `;
+    toggleApiKeyBtn.ariaLabel = 'Show API Key';
+  }
 });
 
 providerSelect.addEventListener('change', () => {

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -55,6 +55,34 @@ header p {
   margin-bottom: 0;
 }
 
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #6b7280;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+}
+
+#apiKey {
+  padding-right: 40px;
+}
+
 label {
   display: block;
   font-size: 14px;


### PR DESCRIPTION
💡 What: Added a show/hide toggle button to the OpenRouter API Key input field in the settings page.
🎯 Why: Users often need to verify their API key, and having it always hidden is inconvenient. This improves usability while maintaining security.
📸 Before/After: (Screenshot verification completed)
♿ Accessibility: Added proper `aria-label` to the toggle button which updates based on state ("Show API Key" / "Hide API Key"). The button is keyboard accessible.

---
*PR created automatically by Jules for task [7371428249319372666](https://jules.google.com/task/7371428249319372666) started by @devin201o*