### PR TITLE
🎨 Palette: Add show/hide password toggle to API key field

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,19 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" class="toggle-password-btn" id="toggleApiKeyBtn" aria-label="Show password" title="Show password">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,10 +21,30 @@ const discreteModeToggle = document.getElementById('discreteMode') as HTMLInputE
 const opacityGroup = document.getElementById('opacityGroup') as HTMLDivElement;
 const opacitySlider = document.getElementById('discreteModeOpacity') as HTMLInputElement;
 const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
+const toggleApiKeyBtn = document.getElementById('toggleApiKeyBtn') as HTMLButtonElement;
 
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
 };
+
+const iconEye = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>`;
+const iconEyeOff = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye-off"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>`;
+
+if (toggleApiKeyBtn) {
+  toggleApiKeyBtn.addEventListener('click', () => {
+    if (apiKeyInput.type === 'password') {
+      apiKeyInput.type = 'text';
+      toggleApiKeyBtn.innerHTML = iconEyeOff;
+      toggleApiKeyBtn.setAttribute('aria-label', 'Hide password');
+      toggleApiKeyBtn.setAttribute('title', 'Hide password');
+    } else {
+      apiKeyInput.type = 'password';
+      toggleApiKeyBtn.innerHTML = iconEye;
+      toggleApiKeyBtn.setAttribute('aria-label', 'Show password');
+      toggleApiKeyBtn.setAttribute('title', 'Show password');
+    }
+  });
+}
 
 function updateModelDropdown(models: string[], selectedModel: string) {
   modelSelect.innerHTML = '';

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -63,6 +63,35 @@ label {
   color: #374151;
 }
 
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+  background-color: #f3f4f6;
+}
+
 input[type="text"],
 input[type="password"],
 input[type="url"],


### PR DESCRIPTION
* 💡 What: Added a toggle button to show or hide the API key in the settings page.
* 🎯 Why: Entering a long API key like OpenRouter's can be error-prone; letting users view their entry reduces mistakes and friction.
* ♿ Accessibility: The toggle button dynamically updates its `aria-label` and `title` between "Show password" and "Hide password". It is a `type="button"` to avoid form submission.
* 🎨 Palette constraints: Used inline SVGs (no new assets), minimal vanilla CSS modifications (using the existing `src/styles/options.css`), and the change is small but impactful.

---
*PR created automatically by Jules for task [4046481782844039517](https://jules.google.com/task/4046481782844039517) started by @devin201o*