### PR TITLE
🎨 Palette: Add password visibility toggle to API key field

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-01 - Password Visibility Toggle Accessibility
+**Learning:** For interactive toggle buttons (e.g., password visibility), the `aria-label` must be dynamically updated to reflect the current state (e.g., switching from 'Show' to 'Hide') to ensure screen reader accessibility. Additionally, using inline SVGs for simple icons in the options page TS logic simplifies asset handling.
+**Action:** Always dynamically update `aria-label` and `title` attributes on stateful UI toggles, and prefer inline SVGs over external image files for simple UI icons to avoid path resolution issues.

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,17 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" class="toggle-password-btn" aria-label="Show API key" title="Show API key"></button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,9 +21,15 @@ const discreteModeToggle = document.getElementById('discreteMode') as HTMLInputE
 const opacityGroup = document.getElementById('opacityGroup') as HTMLDivElement;
 const opacitySlider = document.getElementById('discreteModeOpacity') as HTMLInputElement;
 const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
+const togglePasswordBtn = document.querySelector('.toggle-password-btn') as HTMLButtonElement;
 
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
+};
+
+const ICONS = {
+  eye: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>`,
+  eyeOff: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>`
 };
 
 function updateModelDropdown(models: string[], selectedModel: string) {
@@ -72,6 +78,21 @@ async function loadSettings() {
   updateEndpointVisibility();
   updateCustomPromptVisibility();
   updateToastDurationState();
+
+  // Initialize password toggle button
+  if (togglePasswordBtn) {
+    togglePasswordBtn.innerHTML = ICONS.eye;
+  }
+}
+
+if (togglePasswordBtn) {
+  togglePasswordBtn.addEventListener('click', () => {
+    const isPassword = apiKeyInput.type === 'password';
+    apiKeyInput.type = isPassword ? 'text' : 'password';
+    togglePasswordBtn.innerHTML = isPassword ? ICONS.eyeOff : ICONS.eye;
+    togglePasswordBtn.setAttribute('aria-label', isPassword ? 'Hide API key' : 'Show API key');
+    togglePasswordBtn.setAttribute('title', isPassword ? 'Hide API key' : 'Show API key');
+  });
 }
 
 function updateCustomPromptVisibility() {

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -55,6 +55,39 @@ header p {
   margin-bottom: 0;
 }
 
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  color: #6b7280;
+  transition: color 0.2s;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+}
+
+.toggle-password-btn svg {
+  width: 20px;
+  height: 20px;
+}
+
 label {
   display: block;
   font-size: 14px;


### PR DESCRIPTION
💡 **What:** Added a password visibility toggle (eye icon) to the OpenRouter API Key field on the settings page.

🎯 **Why:** Users need a way to verify they pasted their API key correctly before saving. Without a toggle, they are left guessing if there were missing characters or extra spaces.

📸 **Before/After:**
*(See Playwright frontend verification screenshots)*

♿ **Accessibility:**
- The toggle button has dynamic `aria-label` and `title` attributes that update based on state (e.g., switches between "Show API key" and "Hide API key").
- Uses semantically correct `<button type="button">`.
- Leverages inline SVGs for simple scalable icons without asset path resolution issues.

---
*PR created automatically by Jules for task [91640649832166930](https://jules.google.com/task/91640649832166930) started by @devin201o*