### PR TITLE
🎨 Palette: [UX improvement] Add visibility toggle to API key field

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2025-03-02 - Dynamic ARIA labels on Toggle Buttons
+**Learning:** For interactive toggle buttons like password visibility switchers, static `aria-label` attributes aren't sufficient. A screen reader needs to know the *current actionable state* (e.g., if the key is hidden, the button should say "Show API Key"; if visible, "Hide API Key").
+**Action:** When creating toggle buttons, add event listeners that dynamically update the `aria-label` and `title` attributes to reflect the immediate action the button will perform, ensuring accurate context for assistive technologies.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+ignoredBuiltDependencies:
+  - esbuild

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,19 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" id="toggleApiKeyBtn" class="toggle-password-btn" aria-label="Show API Key" title="Show API Key">
+              <!-- SVG icon will be injected via JS -->
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -7,6 +7,7 @@ const apiEndpointInput = document.getElementById('apiEndpoint') as HTMLInputElem
 const modelSelect = document.getElementById('model') as HTMLSelectElement;
 const addModelBtn = document.getElementById('addModelBtn') as HTMLButtonElement;
 const deleteModelBtn = document.getElementById('deleteModelBtn') as HTMLButtonElement;
+const toggleApiKeyBtn = document.getElementById('toggleApiKeyBtn') as HTMLButtonElement;
 const maxTokensInput = document.getElementById('maxTokens') as HTMLInputElement;
 const toastPositionSelect = document.getElementById('toastPosition') as HTMLSelectElement;
 const toastDurationInput = document.getElementById('toastDuration') as HTMLInputElement;
@@ -24,6 +25,11 @@ const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
 
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
+};
+
+const ICONS = {
+  eye: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>`,
+  eyeOff: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>`
 };
 
 function updateModelDropdown(models: string[], selectedModel: string) {
@@ -72,6 +78,23 @@ async function loadSettings() {
   updateEndpointVisibility();
   updateCustomPromptVisibility();
   updateToastDurationState();
+  initPasswordToggle();
+}
+
+function initPasswordToggle() {
+  if (toggleApiKeyBtn && apiKeyInput) {
+    toggleApiKeyBtn.innerHTML = ICONS.eye;
+    toggleApiKeyBtn.addEventListener('click', () => {
+      const type = apiKeyInput.getAttribute('type') === 'password' ? 'text' : 'password';
+      apiKeyInput.setAttribute('type', type);
+
+      const isPassword = type === 'password';
+      toggleApiKeyBtn.innerHTML = isPassword ? ICONS.eye : ICONS.eyeOff;
+      const label = isPassword ? 'Show API Key' : 'Hide API Key';
+      toggleApiKeyBtn.setAttribute('aria-label', label);
+      toggleApiKeyBtn.setAttribute('title', label);
+    });
+  }
 }
 
 function updateCustomPromptVisibility() {

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -76,6 +76,42 @@ select {
   transition: border-color 0.2s;
 }
 
+.input-wrapper {
+  position: relative;
+  display: block;
+  width: 100%;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b7280;
+  transition: color 0.2s;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+}
+
+.toggle-password-btn:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 input:focus,
 select:focus {
   outline: none;


### PR DESCRIPTION
💡 **What**: Added a "show/hide" toggle button to the OpenRouter API Key password input field on the extension's options page.
🎯 **Why**: Users often struggle to ensure they pasted long, complex API keys correctly without an easy way to verify the hidden text. This provides immediate visual confirmation while keeping the default secure.
📸 **Before/After**: The input field now has a clear eye icon button inside it that toggles the text visibility. Screenshots of the visible and hidden states were verified via Playwright.
♿ **Accessibility**: Implemented dynamic `aria-label` and `title` attributes that update based on the current state (e.g., from "Show API Key" to "Hide API Key") so screen reader users have proper context about what the button will do. Additionally, the button is keyboard focusable and styled with a clear `focus-visible` ring.

---
*PR created automatically by Jules for task [15786809214851707130](https://jules.google.com/task/15786809214851707130) started by @devin201o*