### PR TITLE
🎨 Palette: Add show/hide toggle to API key field

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Dynamic ARIA labels for toggles
+**Learning:** For interactive toggle buttons (e.g., password visibility), the `aria-label` must be dynamically updated to reflect the current state (e.g., switching from 'Show' to 'Hide') to ensure screen reader accessibility. This pattern is specific to this app's components to ensure robust accessibility.
+**Action:** When creating toggle buttons, use JavaScript to update the `aria-label` and `title` attributes whenever the state changes.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+ignoredBuiltDependencies:
+  - esbuild

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,19 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" id="toggleApiKeyBtn" class="toggle-password-btn btn-icon" aria-label="Show API key" title="Show API key">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye"><path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/></svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,6 +3,7 @@ import { ExtensionSettings, DEFAULT_SETTINGS } from './types';
 const form = document.getElementById('settingsForm') as HTMLFormElement;
 const providerSelect = document.getElementById('provider') as HTMLSelectElement;
 const apiKeyInput = document.getElementById('apiKey') as HTMLInputElement;
+const toggleApiKeyBtn = document.getElementById('toggleApiKeyBtn') as HTMLButtonElement;
 const apiEndpointInput = document.getElementById('apiEndpoint') as HTMLInputElement;
 const modelSelect = document.getElementById('model') as HTMLSelectElement;
 const addModelBtn = document.getElementById('addModelBtn') as HTMLButtonElement;
@@ -25,6 +26,9 @@ const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
 };
+
+const iconEye = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye"><path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/></svg>`;
+const iconEyeOff = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye-off"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>`;
 
 function updateModelDropdown(models: string[], selectedModel: string) {
   modelSelect.innerHTML = '';
@@ -94,6 +98,21 @@ providerSelect.addEventListener('change', () => {
   }
   updateEndpointVisibility();
   updateOpacityGroupVisibility();
+});
+
+toggleApiKeyBtn.addEventListener('click', () => {
+  const type = apiKeyInput.getAttribute('type') === 'password' ? 'text' : 'password';
+  apiKeyInput.setAttribute('type', type);
+
+  if (type === 'password') {
+    toggleApiKeyBtn.innerHTML = iconEye;
+    toggleApiKeyBtn.setAttribute('aria-label', 'Show API key');
+    toggleApiKeyBtn.setAttribute('title', 'Show API key');
+  } else {
+    toggleApiKeyBtn.innerHTML = iconEyeOff;
+    toggleApiKeyBtn.setAttribute('aria-label', 'Hide API key');
+    toggleApiKeyBtn.setAttribute('title', 'Hide API key');
+  }
 });
 
 function updateToastDurationState() {

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -90,6 +90,36 @@ small {
   color: #6b7280;
 }
 
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 8px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b7280;
+  width: auto;
+  height: auto;
+  padding: 4px;
+}
+
+.toggle-password-btn:hover {
+  background: transparent;
+  color: #374151;
+}
+
 .form-group-toggle {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
💡 **What**: Added a show/hide visibility toggle to the OpenRouter API Key input field on the options page.
🎯 **Why**: Users often need to verify they've pasted or typed their API key correctly before saving. Without a visibility toggle, this is impossible, leading to potential frustration or repeated pasting.
📸 **Before/After**: The field previously only showed `sk-or-...` and asterisks when typing. Now, it has an eye icon on the right side that can be clicked to reveal the key.
♿ **Accessibility**: Added a dynamic `aria-label` and `title` to the toggle button. When the key is hidden, the label is "Show API key". When the key is visible, it updates to "Hide API key", providing accurate context for screen reader users.

---
*PR created automatically by Jules for task [529653495432093766](https://jules.google.com/task/529653495432093766) started by @devin201o*