### PR TITLE
🎨 Palette: Add password visibility toggle to API key field

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2025-03-05 - Password Visibility Toggle
+**Learning:** For password fields, placing a toggle button over the input field can cause text overlap. The `aria-label` must dynamically update for screen readers when the toggle state changes.
+**Action:** When creating password toggles, wrap the input in an `.input-wrapper`, give the input right padding (e.g. 40px) to make room for the absolutely positioned `.toggle-password-btn`, and ensure the TS logic updates the button's `aria-label` (e.g. "Show password" -> "Hide password").

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "devDependencies": {
     "@types/chrome": "^0.0.268",
+    "@types/jsdom": "^28.0.0",
+    "@types/node": "^25.3.5",
     "jsdom": "^27.0.0",
     "typescript": "^5.3.3",
     "vite": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@types/chrome':
         specifier: ^0.0.268
         version: 0.0.268
+      '@types/jsdom':
+        specifier: ^28.0.0
+        version: 28.0.0
+      '@types/node':
+        specifier: ^25.3.5
+        version: 25.3.5
       jsdom:
         specifier: ^27.0.0
         version: 27.4.0
@@ -19,13 +25,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^5.0.0
-        version: 5.4.21
+        version: 5.4.21(@types/node@25.3.5)
       vite-plugin-static-copy:
         specifier: ^3.1.3
-        version: 3.2.0(vite@5.4.21)
+        version: 3.2.0(vite@5.4.21(@types/node@25.3.5))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(jsdom@27.4.0)
+        version: 3.2.4(@types/node@25.3.5)(jsdom@27.4.0)
 
 packages:
 
@@ -368,6 +374,15 @@ packages:
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
+  '@types/jsdom@28.0.0':
+    resolution: {integrity: sha512-A8TBQQC/xAOojy9kM8E46cqT00sF0h7dWjV8t8BJhUi2rG6JRh7XXQo/oLoENuZIQEpXsxLccLCnknyQd7qssQ==}
+
+  '@types/node@25.3.5':
+    resolution: {integrity: sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -577,6 +592,9 @@ packages:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
@@ -687,6 +705,12 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici-types@7.22.0:
+    resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1016,6 +1040,19 @@ snapshots:
 
   '@types/har-format@1.2.16': {}
 
+  '@types/jsdom@28.0.0':
+    dependencies:
+      '@types/node': 25.3.5
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+      undici-types: 7.22.0
+
+  '@types/node@25.3.5':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/tough-cookie@4.0.5': {}
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -1024,13 +1061,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.21)':
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@25.3.5))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.3.5)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1259,6 +1296,10 @@ snapshots:
 
   p-map@7.0.4: {}
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
@@ -1371,13 +1412,17 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  vite-node@3.2.4:
+  undici-types@7.18.2: {}
+
+  undici-types@7.22.0: {}
+
+  vite-node@3.2.4(@types/node@25.3.5):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.3.5)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -1389,27 +1434,28 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-static-copy@3.2.0(vite@5.4.21):
+  vite-plugin-static-copy@3.2.0(vite@5.4.21(@types/node@25.3.5)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.4
       picocolors: 1.1.1
       tinyglobby: 0.2.15
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.3.5)
 
-  vite@5.4.21:
+  vite@5.4.21(@types/node@25.3.5):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.57.1
     optionalDependencies:
+      '@types/node': 25.3.5
       fsevents: 2.3.3
 
-  vitest@3.2.4(jsdom@27.4.0):
+  vitest@3.2.4(@types/node@25.3.5)(jsdom@27.4.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.21)
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@25.3.5))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1427,10 +1473,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.21
-      vite-node: 3.2.4
+      vite: 5.4.21(@types/node@25.3.5)
+      vite-node: 3.2.4(@types/node@25.3.5)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 25.3.5
       jsdom: 27.4.0
     transitivePeerDependencies:
       - less

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+ignoredBuiltDependencies:
+  - esbuild

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,18 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" class="toggle-password-btn" id="togglePasswordBtn" aria-label="Show password">
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,10 +21,26 @@ const discreteModeToggle = document.getElementById('discreteMode') as HTMLInputE
 const opacityGroup = document.getElementById('opacityGroup') as HTMLDivElement;
 const opacitySlider = document.getElementById('discreteModeOpacity') as HTMLInputElement;
 const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
+const togglePasswordBtn = document.getElementById('togglePasswordBtn') as HTMLButtonElement;
 
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
 };
+
+const EYE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye"><path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/></svg>`;
+const EYE_OFF_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye-off"><path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49"/><path d="M14.084 14.158a3 3 0 0 1-4.242-4.242"/><path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143"/><path d="m2 2 20 20"/></svg>`;
+
+// Initialize the password toggle icon
+if (togglePasswordBtn) {
+  togglePasswordBtn.innerHTML = EYE_ICON;
+}
+
+togglePasswordBtn.addEventListener('click', () => {
+  const isPassword = apiKeyInput.type === 'password';
+  apiKeyInput.type = isPassword ? 'text' : 'password';
+  togglePasswordBtn.innerHTML = isPassword ? EYE_OFF_ICON : EYE_ICON;
+  togglePasswordBtn.setAttribute('aria-label', isPassword ? 'Hide password' : 'Show password');
+});
 
 function updateModelDropdown(models: string[], selectedModel: string) {
   modelSelect.innerHTML = '';

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -96,6 +96,39 @@ small {
   align-items: center;
 }
 
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b7280;
+  transition: color 0.2s;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+}
+
+.toggle-password-btn svg {
+  width: 20px;
+  height: 20px;
+}
+
 .form-group-toggle label {
   margin-bottom: 0;
 }


### PR DESCRIPTION
💡 What: Added a "Show/Hide Password" toggle button with an eye/eye-off icon to the API key input field in the extension settings page.
🎯 Why: To improve usability by allowing users to double-check their long API keys before saving, preventing typos while maintaining security.
📸 Before/After: Visual changes verified; added an `.input-wrapper` to cleanly position the absolute toggle over the right-padded input field. 
♿ Accessibility: The toggle uses standard standard Lucide SVGs, operates via an interactive `<button>`, and dynamically updates its `aria-label` attribute (between "Show password" and "Hide password") to ensure compatibility with screen readers as its state changes.

Additionally, added a UI pattern note to `.Jules/palette.md` to document this approach for future input fields.

---
*PR created automatically by Jules for task [14834188892919858353](https://jules.google.com/task/14834188892919858353) started by @devin201o*