### PR TITLE
🎨 Palette: Add focus-visible states to toggle switches

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Visually Hidden Checkboxes Require Explicit Focus Styles
+**Learning:** Custom toggle switches implemented with visually hidden (`opacity: 0`) checkboxes lose their native focus ring. Without explicit focus styles, they violate WCAG 2.4.7 (Focus Visible), making keyboard navigation impossible.
+**Action:** Always add an adjacent sibling selector with `:focus-visible` (e.g., `input[type="checkbox"]:focus-visible + .slider`) applying a clear box-shadow when using `opacity: 0` to hide native checkbox inputs for custom toggles.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+ignoredBuiltDependencies:
+  - esbuild

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -145,6 +145,10 @@ input:checked + .slider:before {
   transform: translateX(22px);
 }
 
+.toggle-switch input:focus-visible + .slider {
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.5);
+}
+
 .slider-container {
   display: flex;
   align-items: center;

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -70,6 +70,10 @@ h1 {
   transform: translateX(20px);
 }
 
+.toggle-label input[type="checkbox"]:focus-visible + .toggle-slider {
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.5);
+}
+
 .toggle-text {
   font-size: 14px;
   color: #374151;


### PR DESCRIPTION
💡 **What:** Added visible focus rings to all toggle switches (`options.html` and `popup.html`) when navigating via keyboard.

🎯 **Why:** The native `<input type="checkbox">` elements were visually hidden (`opacity: 0`) to style the custom toggle track/thumb. Because the native input was hidden, it also hid the browser's default focus ring, violating WCAG 2.4.7 (Focus Visible) and making keyboard navigation nearly impossible for screen reader and keyboard-only users.

📸 **Before/After:** The toggles now display a clear blue `box-shadow` outline when focused via the `Tab` key, matching the visual focus style of other interactive elements like buttons and text inputs.

♿ **Accessibility:** This directly fixes a severe keyboard navigation issue, restoring clear visual indication of focus for the custom toggle components.

---
*PR created automatically by Jules for task [3044170900114947737](https://jules.google.com/task/3044170900114947737) started by @devin201o*