### PR TITLE
🎨 Palette: Add API key visibility toggle and custom toggle focus states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Password Field Toggles and Custom Checkboxes
+**Learning:** For interactive toggle buttons (like password visibility), `aria-label` must dynamically update based on state. Additionally, custom toggle switches that visually hide checkboxes require explicit `:focus-visible` styling on the visible elements to maintain keyboard accessibility.
+**Action:** When creating toggle buttons or custom checkboxes, ensure dynamic ARIA labels and explicit focus styles are applied for a11y compliance.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+ignoredBuiltDependencies:
+  - esbuild

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,19 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" class="toggle-password-btn" id="toggleApiKey" aria-label="Show API Key" title="Show API Key">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye"><path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/></svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,6 +21,7 @@ const discreteModeToggle = document.getElementById('discreteMode') as HTMLInputE
 const opacityGroup = document.getElementById('opacityGroup') as HTMLDivElement;
 const opacitySlider = document.getElementById('discreteModeOpacity') as HTMLInputElement;
 const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
+const toggleApiKeyBtn = document.getElementById('toggleApiKey') as HTMLButtonElement;
 
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
@@ -107,6 +108,18 @@ discreteModeToggle.addEventListener('change', updateOpacityGroupVisibility);
 opacitySlider.addEventListener('input', () => {
   opacityValue.textContent = opacitySlider.value;
 });
+
+if (toggleApiKeyBtn && apiKeyInput) {
+  toggleApiKeyBtn.addEventListener('click', () => {
+    const isPassword = apiKeyInput.type === 'password';
+    apiKeyInput.type = isPassword ? 'text' : 'password';
+    toggleApiKeyBtn.setAttribute('aria-label', isPassword ? 'Hide API Key' : 'Show API Key');
+    toggleApiKeyBtn.setAttribute('title', isPassword ? 'Hide API Key' : 'Show API Key');
+    toggleApiKeyBtn.innerHTML = isPassword
+      ? '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye-off"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>'
+      : '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye"><path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/></svg>';
+  });
+}
 
 addModelBtn.addEventListener('click', async () => {
   const newModel = prompt('Enter the new model name:');

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -76,6 +76,41 @@ select {
   transition: border-color 0.2s;
 }
 
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  background: none;
+  border: none;
+  color: #6b7280;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border-radius: 4px;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+  background-color: #f3f4f6;
+}
+
+.toggle-password-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #3b82f6;
+}
+
 input:focus,
 select:focus {
   outline: none;
@@ -135,6 +170,11 @@ small {
   background-color: white;
   transition: .4s;
   border-radius: 50%;
+}
+
+input:focus-visible + .slider {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
 }
 
 input:checked + .slider {

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -62,6 +62,11 @@ h1 {
   transition: transform 0.3s;
 }
 
+.toggle-label input:focus-visible + .toggle-slider {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+
 .toggle-label input:checked + .toggle-slider {
   background: #3b82f6;
 }


### PR DESCRIPTION
💡 **What:** 
- Added a "Show/Hide Password" toggle button for the OpenRouter API Key input field in the Settings page.
- Added explicit `:focus-visible` CSS outlines to custom toggle sliders across the app (Settings and Popup).
- Created a `.Jules/palette.md` file logging this learning.

🎯 **Why:** 
- Typing an API key is prone to errors, and users often need a way to verify what they pasted or typed.
- Custom toggle switches (where the actual checkbox is visually hidden via `opacity: 0`) lose default browser focus rings. Keyboard users cannot see which toggle is currently focused without explicit `:focus-visible` styling applied to the adjacent visible element (the slider).

📸 **Before/After:**
*(See Playwright verification screenshots in the PR)*

♿ **Accessibility:** 
- The toggle button uses dynamic `aria-label`s and `title`s ("Show API Key" / "Hide API Key") that update based on state, making it screen-reader friendly.
- The button itself has explicit focus states.
- Restored missing keyboard focus indicators on all custom toggle switches in the extension.

---
*PR created automatically by Jules for task [6422628926713195792](https://jules.google.com/task/6422628926713195792) started by @devin201o*