### PR TITLE
🎨 Palette: Add show/hide toggle for API Key

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Dynamic ARIA Labels for Toggles
+**Learning:** When using icon-only buttons for toggles (like showing/hiding a password), the `aria-label` must be dynamically updated to reflect the new action the user will take, ensuring screen reader users understand the current state and what will happen when they interact with it.
+**Action:** When implementing toggles, always link the `aria-label` update to the state change logic in TypeScript.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+ignoredBuiltDependencies:
+  - esbuild

--- a/src/options.html
+++ b/src/options.html
@@ -26,14 +26,19 @@
 
         <div class="form-group">
           <label for="apiKey">OpenRouter API Key *</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            name="apiKey" 
-            placeholder="sk-or-..." 
-            required 
-            aria-describedby="apiKeyHelp"
-          />
+          <div class="input-wrapper">
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              placeholder="sk-or-..."
+              required
+              aria-describedby="apiKeyHelp"
+            />
+            <button type="button" class="toggle-password-btn" id="toggleApiKeyBtn" aria-label="Show password">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-eye"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>
+            </button>
+          </div>
           <small id="apiKeyHelp">Your API key is stored locally and never sent anywhere except to OpenRouter API.</small>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,9 +21,15 @@ const discreteModeToggle = document.getElementById('discreteMode') as HTMLInputE
 const opacityGroup = document.getElementById('opacityGroup') as HTMLDivElement;
 const opacitySlider = document.getElementById('discreteModeOpacity') as HTMLInputElement;
 const opacityValue = document.getElementById('opacityValue') as HTMLSpanElement;
+const toggleApiKeyBtn = document.getElementById('toggleApiKeyBtn') as HTMLButtonElement;
 
 const ENDPOINTS = {
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
+};
+
+const ICONS = {
+  eye: '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-eye"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>',
+  eyeOff: '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-eye-off"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24M1 1l22 22"></path></svg>',
 };
 
 function updateModelDropdown(models: string[], selectedModel: string) {
@@ -106,6 +112,18 @@ discreteModeToggle.addEventListener('change', updateOpacityGroupVisibility);
 
 opacitySlider.addEventListener('input', () => {
   opacityValue.textContent = opacitySlider.value;
+});
+
+toggleApiKeyBtn.addEventListener('click', () => {
+  if (apiKeyInput.type === 'password') {
+    apiKeyInput.type = 'text';
+    toggleApiKeyBtn.innerHTML = ICONS.eyeOff;
+    toggleApiKeyBtn.setAttribute('aria-label', 'Hide password');
+  } else {
+    apiKeyInput.type = 'password';
+    toggleApiKeyBtn.innerHTML = ICONS.eye;
+    toggleApiKeyBtn.setAttribute('aria-label', 'Show password');
+  }
 });
 
 addModelBtn.addEventListener('click', async () => {

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -76,6 +76,39 @@ select {
   transition: border-color 0.2s;
 }
 
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-wrapper input {
+  padding-right: 40px;
+}
+
+.toggle-password-btn {
+  position: absolute;
+  right: 10px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.toggle-password-btn:hover {
+  color: #374151;
+}
+
+.toggle-password-btn:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 input:focus,
 select:focus {
   outline: none;


### PR DESCRIPTION
💡 **What:** Added a "Show/Hide Password" toggle button to the OpenRouter API Key field in the options page.
🎯 **Why:** Users need a way to verify they have pasted their API key correctly without relying entirely on external editors, especially since the field is masked by default for security.
📸 **Before/After:** See the screenshots in the Playwright verification runs.
♿ **Accessibility:** The toggle uses an inline SVG icon-only button, but its `aria-label` dynamically updates between "Show password" and "Hide password" based on the state to maintain clear context for screen reader users. The wrapper handles layout cleanly. Recorded this learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [2238019321518145421](https://jules.google.com/task/2238019321518145421) started by @devin201o*