### PR TITLE
fix: Restore Ctrl+Shift+Space keyboard shortcut

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+ignoredBuiltDependencies:
+  - esbuild

--- a/src/background.ts
+++ b/src/background.ts
@@ -31,7 +31,69 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     sendResponse({ success: true });
     return true; // Indicate async response
   }
+
+  if (message.type === 'TRIGGER_RUN_ASK_LLM') {
+    const tabId = sender.tab?.id;
+    if (tabId) {
+      handleRunAskLlmCommand(tabId, sender.tab?.url);
+    }
+    sendResponse({ success: true });
+    return false;
+  }
 });
+
+async function handleRunAskLlmCommand(tabId: number, url?: string) {
+  if (!url || !/^(https?|file):/.test(url)) {
+    console.log(`Cannot run Ask LLM on an unsupported page: ${url}`);
+    return;
+  }
+
+  try {
+    const injectionResults = await chrome.scripting.executeScript({
+      target: { tabId: tabId },
+      func: () => window.getSelection()?.toString(),
+    });
+
+    if (chrome.runtime.lastError) {
+      console.error(`Error injecting script: ${chrome.runtime.lastError.message}`);
+      return;
+    }
+
+    const selectionText = (injectionResults && injectionResults.length > 0 ? injectionResults[0].result : '') || '';
+    const { settings } = await chrome.storage.local.get('settings');
+    const currentSettings: ExtensionSettings = { ...DEFAULT_SETTINGS, ...(settings || {}) };
+
+    if (!currentSettings.apiKey) {
+      await ensureAndSendMessage(tabId, {
+        type: 'SHOW_TOAST',
+        payload: { message: 'Please set your API key in the extension options.', type: 'error' },
+      });
+      return;
+    }
+
+    if (currentSettings.promptMode === 'manual') {
+      await ensureAndSendMessage(tabId, {
+        type: 'SHOW_INPUT_BOX',
+        payload: { selectionText },
+      });
+    } else {
+      if (selectionText) {
+        await processLLMRequest(selectionText, tabId);
+      } else {
+        await ensureAndSendMessage(tabId, {
+          type: 'SHOW_TOAST',
+          payload: { message: 'No text selected.', type: 'info', duration: 2000 },
+        });
+      }
+    }
+  } catch (e) {
+    console.error('Failed to execute script or process LLM request:', e);
+    await ensureAndSendMessage(tabId, {
+      type: 'SHOW_TOAST',
+      payload: { message: `An error occurred: ${String(e)}`, type: 'error' },
+    });
+  }
+}
 
 chrome.contextMenus.onClicked.addListener(async (info, tab) => {
   if (
@@ -81,61 +143,7 @@ chrome.commands.onCommand.addListener(async (command) => {
       return;
     }
 
-    // Ensure the extension doesn't run on unsupported pages
-    if (!/^(https?|file):/.test(tab.url)) {
-      console.log(`Cannot run Ask LLM on an unsupported page: ${tab.url}`);
-      return;
-    }
-
-    try {
-      const injectionResults = await chrome.scripting.executeScript({
-        target: { tabId: tab.id },
-        func: () => window.getSelection()?.toString(),
-      });
-
-      if (chrome.runtime.lastError) {
-        console.error(`Error injecting script: ${chrome.runtime.lastError.message}`);
-        return;
-      }
-
-      // We can get an empty result, which is fine.
-      const selectionText = (injectionResults && injectionResults.length > 0 ? injectionResults[0].result : '') || '';
-
-      const { settings } = await chrome.storage.local.get('settings');
-      const currentSettings: ExtensionSettings = { ...DEFAULT_SETTINGS, ...(settings || {}) };
-
-      if (!currentSettings.apiKey) {
-         await ensureAndSendMessage(tab.id, {
-           type: 'SHOW_TOAST',
-           payload: { message: 'Please set your API key in the extension options.', type: 'error' },
-         });
-         return;
-      }
-
-      if (currentSettings.promptMode === 'manual') {
-        // In manual mode, always show the input box, even if there's no selection.
-        await ensureAndSendMessage(tab.id, {
-          type: 'SHOW_INPUT_BOX',
-          payload: { selectionText }, // selectionText can be ''
-        });
-      } else {
-        // In other modes (auto, custom), require a text selection.
-        if (selectionText) {
-          await processLLMRequest(selectionText, tab.id);
-        } else {
-          await ensureAndSendMessage(tab.id, {
-            type: 'SHOW_TOAST',
-            payload: { message: 'No text selected.', type: 'info', duration: 2000 },
-          });
-        }
-      }
-    } catch (e) {
-      console.error('Failed to execute script or process LLM request:', e);
-       await ensureAndSendMessage(tab.id, {
-         type: 'SHOW_TOAST',
-         payload: { message: `An error occurred: ${String(e)}`, type: 'error' },
-       });
-    }
+    handleRunAskLlmCommand(tab.id, tab.url);
   }
 });
 
@@ -246,7 +254,7 @@ async function updateContextMenu() {
 }
 
 async function pingTab(tabId: number): Promise<boolean> {
-  let timeout: NodeJS.Timeout;
+  let timeout: ReturnType<typeof setTimeout>;
   return new Promise((resolve) => {
     timeout = setTimeout(() => {
       console.log(`Ping timeout for tab ${tabId}`);

--- a/src/content.ts
+++ b/src/content.ts
@@ -8,6 +8,13 @@ let currentInputBox: HTMLDivElement | null = null;
 
 // --- EVENT LISTENERS ---
 
+document.addEventListener('keydown', (e) => {
+  if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.code === 'Space') {
+    e.preventDefault();
+    chrome.runtime.sendMessage({ type: 'TRIGGER_RUN_ASK_LLM' });
+  }
+});
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'SHOW_TOAST') {
     (async () => {


### PR DESCRIPTION
This PR restores the functionality of the `Ctrl+Shift+Space` keyboard shortcut for triggering the extension. 

### What
- Implemented a `keydown` event listener in `src/content.ts` that explicitly listens for `Ctrl+Shift+Space` (and `Cmd+Shift+Space` for macOS).
- Refactored the core execution logic in `src/background.ts` into a reusable `handleRunAskLlmCommand` function.
- Added a new message listener in `src/background.ts` for `TRIGGER_RUN_ASK_LLM` to execute the command when the content script detects the shortcut.
- Replaced a `NodeJS.Timeout` typing in `src/background.ts` with `ReturnType<typeof setTimeout>` to resolve a pre-existing TypeScript compilation error in the build step.

### Why
Chrome strictly enforces a policy where the `Space` key is an invalid shortcut modifier in `manifest.json` `commands` for any OS other than ChromeOS. Previously, this worked for users because they may have manually set it or relied on an older caching behavior, but changing the command ID from `toggle-extension` to `run-ask-llm` wiped those manual settings. Because the new default (`Ctrl+Shift+Space`) was technically invalid on Windows/Mac, Chrome silently ignored it. 

By handling the shortcut manually in the content script, we bypass Chrome's `manifest.json` restrictions entirely, ensuring the user gets their exact requested shortcut working out-of-the-box without requiring manual configuration in `chrome://extensions/shortcuts`.

---
*PR created automatically by Jules for task [6868845447861644092](https://jules.google.com/task/6868845447861644092) started by @devin201o*